### PR TITLE
fix(wrappers): properly reverse if check in async extractor

### DIFF
--- a/wrappers/wrappers.go
+++ b/wrappers/wrappers.go
@@ -141,20 +141,17 @@ func WrapExtractFuncs(plgState unsafe.Pointer, evt unsafe.Pointer, numFields uin
 		switch uint32(flds[i].ftype) {
 		case sdk.ParamTypeCharBuf:
 			present, str := strExtractorFunc(plgState, uint64(event.evtnum), dataBuf, uint64(event.ts), fieldStr, argStr)
+			flds[i].field_present = C.bool(present)
 			if present {
-				flds[i].field_present = C.bool(true)
 				flds[i].res_str = C.CString(str)
 			} else {
-				flds[i].field_present = C.bool(false)
 				flds[i].res_str = nil
 			}
 		case sdk.ParamTypeUint64:
 			present, u64 := u64ExtractorFunc(plgState, uint64(event.evtnum), dataBuf, uint64(event.ts), fieldStr, argStr)
+			flds[i].field_present = C.bool(present)
 			if present {
-				flds[i].field_present = C.bool(true)
 				flds[i].res_u64 = C.uint64_t(u64)
-			} else {
-				flds[i].field_present = C.bool(false)
 			}
 		}
 	}
@@ -212,11 +209,10 @@ func RegisterAsyncExtractors(
 				if strExtractorFunc != nil {
 					present, str := strExtractorFunc(pluginState, uint64(info.evt.evtnum), dataBuf, uint64(info.evt.ts), fieldStr, argStr)
 
+					info.field.field_present = C.bool(present)
 					if present {
-						info.field.field_present = C.bool(true)
 						info.field.res_str = C.CString(str)
 					} else {
-						info.field.field_present = C.bool(false)
 						info.field.res_str = nil
 					}
 				} else {
@@ -226,10 +222,8 @@ func RegisterAsyncExtractors(
 				if u64ExtractorFunc != nil {
 					present, u64 := u64ExtractorFunc(pluginState, uint64(info.evt.evtnum), dataBuf, uint64(info.evt.ts), fieldStr, argStr)
 
-					if (!present){
-						info.field.field_present = C.bool(true)
-					} else {
-						info.field.field_present = C.bool(false)
+					info.field.field_present = C.bool(present)
+					if present {
 						info.field.res_u64 = C.uint64_t(u64)
 					}
 				} else {


### PR DESCRIPTION
```
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>
Co-authored-by: Jason Dellaluce <jasondellaluce@gmail.com>
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>
```

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area plugin-sdk

**What this PR does / why we need it**:

Fixes ParamTypeUint64 switch case in RegisterAsyncExtractors to properly set the `field_present` bool and `res_u64` value when present is true.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
Fixes uint64 usage in async extractor.
```
