### PR TITLE
plugin_next_batch should return success when batch < max batch size

### DIFF
--- a/wrappers/wrappers.go
+++ b/wrappers/wrappers.go
@@ -283,6 +283,15 @@ func NextBatch(plgState unsafe.Pointer, openState unsafe.Pointer, nextf NextFunc
 			// Return success but stop
 			res = sdk.SSPluginSuccess
 			break
+		} else if res == sdk.SSPluginTimeout {
+			// Return success if there are any events
+			// queued up, otherwise pass the timeout
+			// along.
+			if len(evts) > 0 {
+				res = sdk.SSPluginSuccess
+			}
+
+			break
 		} else {
 			break
 		}


### PR DESCRIPTION
When using the NextBatch wrapper, NextBatch calls the provided next
function until a non-SSPluginSuccess value is returned.

There was a bug in this, where a timeout from the underlying next
function would be passed up to the framework, even if there were some
pending events (think fewer than max batch size).

The fix is to change a timeout to success if there are any events to
return.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
Fix plugin_next_batch wrapper to properly return success when less than a full batch of events is returned.
```
