### PR TITLE
Divorce plugin rcs from libscap rcs

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -22,13 +22,8 @@ const (
 	SSPluginSuccess         int32 = 0
 	SSPluginFailure         int32 = 1
 	SSPluginTimeout         int32 = -1
-	SSPluginIllegalInput    int32 = 3
-	SSPluginNotFound        int32 = 4
-	SSPluginInputTooSmall   int32 = 5
-	SSPluginEOF             int32 = 6
-	SSPluginUnexpectedBlock int32 = 7
-	SSPluginVersionMismatch int32 = 8
-	SSPluginNotSupported    int32 = 9
+	SSPluginEOF             int32 = 2
+	SSPluginNotSupported    int32 = 3
 )
 
 // One of these values should be returned by plugin_get_type().


### PR DESCRIPTION
Change the values to only those that are relevant for plugins. The
plugin framework keeps the values separate and converts when necessary.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
