### PR TITLE
update: add accessor for field type in ExtractRequest

### DIFF
--- a/pkg/sdk/extract.go
+++ b/pkg/sdk/extract.go
@@ -34,6 +34,11 @@ type ExtractRequest interface {
 	// returned by plugin_get_fields
 	FieldID() uint64
 	//
+	// FieldType returns the type of the field for which the value extraction
+	// is requested. For now, only sdk.ParamTypeUint64 and
+	// sdk.ParamTypeCharBuf are supported.
+	FieldType() uint32
+	//
 	// Field returns the name of the field for which the value extraction
 	// is requested.
 	Field() string
@@ -109,6 +114,10 @@ func (e *extractRequest) SetPtr(pef unsafe.Pointer) {
 
 func (e *extractRequest) FieldID() uint64 {
 	return uint64(e.req.field_id)
+}
+
+func (e *extractRequest) FieldType() uint32 {
+	return uint32(e.req.ftype)
 }
 
 func (e *extractRequest) Field() string {


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind design

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:
This adds the `FieldType()` accessor to the `sdk.ExtractRequest` interface. This is useful in field extraction to implement type-based reasoning and to potentially achieve better performance.

Without this accessor, plugin developers need to maintain knowledge about the type of each supported field across multiple code parts, which leads to a more verbose and dirty codebase. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
