### PR TITLE
refactor: use a type-agnostic SetValue method in ExtractRequest

### DIFF
--- a/examples/custom/custom.go
+++ b/examples/custom/custom.go
@@ -176,7 +176,7 @@ func (p *MyPlugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 
 	switch req.FieldID() {
 	case 0:
-		req.SetStrValue(string(bytes))
+		req.SetValue(string(bytes))
 	default:
 		return fmt.Errorf("unsupported field: %s", req.Field())
 	}

--- a/examples/extractor/extractor.go
+++ b/examples/extractor/extractor.go
@@ -82,7 +82,7 @@ func (m *MyPlugin) Fields() []sdk.FieldEntry {
 func (m *MyPlugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 	switch req.FieldID() {
 	case 0:
-		req.SetU64Value(uint64(time.Now().UnixNano()))
+		req.SetValue(uint64(time.Now().UnixNano()))
 		return nil
 	default:
 		return fmt.Errorf("unsupported field: %s", req.Field())

--- a/examples/full/full.go
+++ b/examples/full/full.go
@@ -119,10 +119,10 @@ func (m *MyPlugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
 
 	switch req.FieldID() {
 	case 0:
-		req.SetU64Value(value)
+		req.SetValue(value)
 		return nil
 	case 1:
-		req.SetStrValue(fmt.Sprintf("%d", value))
+		req.SetValue(fmt.Sprintf("%d", value))
 		return nil
 	default:
 		return fmt.Errorf("unsupported field: %s", req.Field())

--- a/pkg/sdk/extract.go
+++ b/pkg/sdk/extract.go
@@ -47,13 +47,8 @@ type ExtractRequest interface {
 	// is returned if no argument is specified.
 	Arg() string
 	//
-	// SetStrValue sets the extracted value for the requested field.
-	// This must be used for fields of string value type only.
-	SetStrValue(v string)
-	//
-	// SetU64Value sets the extracted value for the requested field.
-	// This must be used for fields of u64 value type only.
-	SetU64Value(v uint64)
+	// SetValue sets the extracted value for the requested field.
+	SetValue(v interface{})
 	//
 	// SetPtr sets a pointer to a ss_plugin_extract_field C structure to
 	// be wrapped in this instance of ExtractRequest.
@@ -128,13 +123,13 @@ func (e *extractRequest) Arg() string {
 	return ptr.GoString(unsafe.Pointer(e.req.arg))
 }
 
-func (e *extractRequest) SetStrValue(v string) {
-	e.strBuf.Write(v)
-	e.req.res_str = (*C.char)(e.strBuf.CharPtr())
-	e.req.field_present = true
-}
-
-func (e *extractRequest) SetU64Value(v uint64) {
-	e.req.res_u64 = (C.ulong)(v)
+func (e *extractRequest) SetValue(v interface{}) {
+	switch e.FieldType() {
+	case ParamTypeUint64:
+		e.req.res_u64 = (C.ulong)(v.(uint64))
+	case ParamTypeCharBuf:
+		e.strBuf.Write(v.(string))
+		e.req.res_str = (*C.char)(e.strBuf.CharPtr())
+	}
 	e.req.field_present = true
 }

--- a/pkg/sdk/extract.go
+++ b/pkg/sdk/extract.go
@@ -48,6 +48,10 @@ type ExtractRequest interface {
 	Arg() string
 	//
 	// SetValue sets the extracted value for the requested field.
+	//
+	// The underlying type of v must be compatible with the field type
+	// associated to this extract request (as the returned by FieldType()),
+	// otherwise SetValue will panic.
 	SetValue(v interface{})
 	//
 	// SetPtr sets a pointer to a ss_plugin_extract_field C structure to
@@ -130,6 +134,8 @@ func (e *extractRequest) SetValue(v interface{}) {
 	case ParamTypeCharBuf:
 		e.strBuf.Write(v.(string))
 		e.req.res_str = (*C.char)(e.strBuf.CharPtr())
+	default:
+		panic("plugin-sdk-go/sdk: called SetValue with unsupported field type")
 	}
 	e.req.field_present = true
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind design

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:
This removes the type-specific `SetU64Value` and `SetStrValue` methods from the `ExtractRequest` interface, to add a type-agnostic `SetValue(v interface{}` method instead. This brings the following benefits:

1. The interface will never change once new field types are supported (it will not be a breaking change)
2. Plugin codebases can become cleaner, as they don't have to be mindful of type-specific cases
3. Type checking is handled internally: better control (setting a wrong type leads to a panic), and better error handling (the panic message explicitly communicates which type casting failed).
4. Type casting is fairly performant because it does not use reflection, but becomes a simple switch statement based on the field type info provided by the framework.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
