### PR TITLE
Increase the default event limit to 256k

### DIFF
--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -47,11 +47,11 @@ const (
 
 // DefaultEvtSize is the default size for the data payload allocated
 // for each event in the EventWriters interface used by the SDK.
-const DefaultEvtSize uint32 = 64 * 1024
+const DefaultEvtSize uint32 = 256 * 1024
 
 // DefaultBatchSize is the default number of events in the EventWriters
 // interface used by the SDK.
-const DefaultBatchSize = 512
+const DefaultBatchSize = 128
 
 // The full set of values that someday might be returned in the ftype
 // member of ss_plugin_extract_field structs. For now, only


### PR DESCRIPTION
Plugin events are no longer capped at 64k, and we think 64k might be
too small for some plugins, so change the default to 256k.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
