### PR TITLE
test: introducing tests in every package and increase coverage

### DIFF
--- a/pkg/ptr/bytes.go
+++ b/pkg/ptr/bytes.go
@@ -181,7 +181,6 @@ func (b *bytesReadWriter) Seek(offset int64, whence int) (int64, error) {
 	default:
 		return b.offset, fmt.Errorf(whenceErrorFmt, whence)
 	}
-	b.offset = offset
 	return b.offset, nil
 }
 

--- a/pkg/ptr/bytes_test.go
+++ b/pkg/ptr/bytes_test.go
@@ -107,6 +107,65 @@ func TestBytesReadWriterPointer(t *testing.T) {
 	}
 }
 
+func TestBytesReadWriterSeek(t *testing.T) {
+	// Allocate a memory buffer and wrap it in a BytesReadWriter
+	_, bytesReadWriter, err := createAndWrapBytes(128, byte(10))
+	if err != nil {
+		t.Error(err)
+	}
+
+	pos, err := bytesReadWriter.Seek(5, io.SeekStart)
+	if err != nil {
+		t.Error(err)
+	} else if pos != 5 {
+		t.Errorf("wrong seek result (SeekStart): expected %d, but found %d", 5, pos)
+	}
+
+	pos, err = bytesReadWriter.Seek(10, io.SeekCurrent)
+	if err != nil {
+		t.Error(err)
+	} else if pos != 15 {
+		t.Errorf("wrong seek result (SeekCurrent): expected %d, but found %d", 15, pos)
+	}
+
+	pos, err = bytesReadWriter.Seek(0, io.SeekEnd)
+	if err != nil {
+		t.Error(err)
+	} else if pos != 128 {
+		t.Errorf("wrong seek result (SeekEnd): expected %d, but found %d", 128, pos)
+	}
+
+	// Wrong whence
+	_, err = bytesReadWriter.Seek(0, io.SeekEnd+1)
+	if err == nil {
+		t.Errorf("err should not be nil")
+	}
+
+	// Negative offset
+	_, err = bytesReadWriter.Seek(-1, io.SeekStart)
+	if err == nil {
+		t.Errorf("err should not be nil")
+	}
+
+	// Going beyond the buffer len (SeekCurrent)
+	_, err = bytesReadWriter.Seek(1, io.SeekCurrent)
+	if err == nil {
+		t.Errorf("err should not be nil")
+	}
+
+	// Going beyond the buffer len (SeekEnd)
+	_, err = bytesReadWriter.Seek(129, io.SeekEnd)
+	if err == nil {
+		t.Errorf("err should not be nil")
+	}
+
+	// Going beyond the buffer len (SeekStart)
+	_, err = bytesReadWriter.Seek(129, io.SeekStart)
+	if err == nil {
+		t.Errorf("err should not be nil")
+	}
+}
+
 func TestBytesReadWriterReadAll(t *testing.T) {
 	// Allocate a memory buffer and wrap it in a BytesReadWriter
 	bytesFillValue := byte(10)

--- a/pkg/ptr/string_test.go
+++ b/pkg/ptr/string_test.go
@@ -49,3 +49,39 @@ func TestGoStringPointer(t *testing.T) {
 		t.Errorf("str=%s, len=%d", str, len(str))
 	}
 }
+
+func TestGoStringNull(t *testing.T) {
+	str := GoString(nil)
+	if len(str) > 0 {
+		t.Errorf("expected empty string")
+	}
+}
+
+func TestStringBuffer(t *testing.T) {
+	str := "hello"
+	buf := &StringBuffer{}
+
+	if buf.CharPtr() != nil {
+		t.Errorf("expected nil char pointer")
+	}
+	if len(buf.String()) > 0 {
+		t.Errorf("expected empty string")
+	}
+
+	buf.Write(str)
+	if buf.CharPtr() == nil {
+		t.Errorf("expected non-nil char pointer")
+	}
+	if buf.String() != str {
+		t.Errorf("string does not match: %s expected, but %s found", str, buf.String())
+	}
+
+	// test reallocation
+	str = str + " world"
+	buf.Write(str)
+	if buf.String() != str {
+		t.Errorf("string does not match: %s expected, but %s found", str, buf.String())
+	}
+
+	buf.Free()
+}

--- a/pkg/sdk/extract_test.go
+++ b/pkg/sdk/extract_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
+)
+
+func allocSSPluginExtractField(fid, ftype uint32, fname, farg string) (*_Ctype_ss_plugin_extract_field, func()) {
+	ret := &_Ctype_ss_plugin_extract_field{}
+	ret.field_id = _Ctype_uint(fid)
+	ret.ftype = _Ctype_uint(ftype)
+
+	argBuf := ptr.StringBuffer{}
+	fnameBuf := ptr.StringBuffer{}
+	fnameBuf.Write(fname)
+	ret.field = (*_Ctype_char)(fnameBuf.CharPtr())
+	if len(farg) > 0 {
+		argBuf.Write(farg)
+		ret.arg = (*_Ctype_char)(argBuf.CharPtr())
+	} else {
+		ret.arg = nil
+	}
+
+	return ret, func() {
+		argBuf.Free()
+		fnameBuf.Free()
+	}
+}
+
+func assertPanic(t *testing.T, fun func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	fun()
+}
+
+func TestNewExtractRequestPool(t *testing.T) {
+	pool := NewExtractRequestPool()
+	// Access should be non-contiguous
+	for i := 0; i < 20; i += 2 {
+		req := pool.Get(i)
+		cstruct, freeCStruct := allocSSPluginExtractField(5, ParamTypeUint64, "test.field", "arg")
+		req.SetPtr(unsafe.Pointer(cstruct))
+		if req.FieldType() != ParamTypeUint64 || req.FieldID() != 5 || req.Field() != "test.field" || req.Arg() != "arg" {
+			println(req.FieldType(), ", ", req.FieldID(), ", ", req.Field(), ", ", req.Arg())
+			t.Errorf("could not read fields from sdk.ExtractRequest")
+		}
+		freeCStruct()
+	}
+	pool.Free()
+}
+
+func TestExtractRequestSetValue(t *testing.T) {
+	pool := NewExtractRequestPool()
+	u64Ptr, freeU64Ptr := allocSSPluginExtractField(1, ParamTypeUint64, "test.u64", "")
+	strPtr, freeStrPtr := allocSSPluginExtractField(2, ParamTypeCharBuf, "test.str", "")
+	u64Req := pool.Get(0)
+	strReq := pool.Get(1)
+	u64Req.SetPtr(unsafe.Pointer(u64Ptr))
+	strReq.SetPtr(unsafe.Pointer(strPtr))
+
+	assertPanic(t, func() {
+		u64Req.SetValue("test")
+	})
+	assertPanic(t, func() {
+		strReq.SetValue(uint64(1))
+	})
+	u64Req.SetValue(uint64(1))
+	strReq.SetValue("test")
+
+	pool.Free()
+	freeU64Ptr()
+	freeStrPtr()
+}

--- a/pkg/sdk/plugins/extractor/extractor_test.go
+++ b/pkg/sdk/plugins/extractor/extractor_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extractor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/info"
+)
+
+type testPlugin struct {
+	plugins.BasePlugin
+}
+
+func (m *testPlugin) Info() *plugins.Info {
+	return &plugins.Info{
+		ID:                  999,
+		Name:                "test",
+		Description:         "Extractor Test",
+		Contact:             "",
+		Version:             "",
+		RequiredAPIVersion:  "",
+		ExtractEventSources: []string{"test"},
+	}
+}
+
+func (m *testPlugin) Init(config string) error {
+	return nil
+}
+
+func (m *testPlugin) Fields() []sdk.FieldEntry {
+	return []sdk.FieldEntry{
+		{Type: "uint64", Name: "test.field", Display: "Test Field", Desc: "Test Field"},
+	}
+}
+
+func (m *testPlugin) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
+	switch req.FieldID() {
+	case 0:
+		req.SetValue(uint64(0))
+		return nil
+	default:
+		return fmt.Errorf("unsupported field: %s", req.Field())
+	}
+}
+
+func assertPanic(t *testing.T, fun func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	fun()
+}
+
+func TestRegister(t *testing.T) {
+	registerFunc := func() {
+		Register(&testPlugin{})
+	}
+	registerFunc()
+	if info.Type() != sdk.TypeExtractorPlugin {
+		t.Errorf("plugin type should be extractor")
+	}
+	assertPanic(t, registerFunc)
+
+	// With source plugin type
+	registered = false
+	info.SetType(sdk.TypeSourcePlugin)
+	Register(&testPlugin{})
+	if info.Type() != sdk.TypeSourcePlugin {
+		t.Errorf("plugin type should be source")
+	}
+
+	// With unknown plugin type
+	registered = false
+	info.SetType(3)
+	assertPanic(t, registerFunc)
+}

--- a/pkg/sdk/plugins/plugins_test.go
+++ b/pkg/sdk/plugins/plugins_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+func TestBaseEvents(t *testing.T) {
+	b := BaseEvents{}
+	value, err := sdk.NewEventWriters(10, 10)
+	if err != nil {
+		t.Error(err)
+	}
+
+	b.SetEvents(value)
+	if b.Events() != value {
+		t.Errorf("Events: value does not match")
+	}
+	value.Free()
+}
+
+func TestBaseExtractRequests(t *testing.T) {
+	b := BaseExtractRequests{}
+	value := sdk.NewExtractRequestPool()
+
+	b.SetExtractRequests(value)
+	if b.ExtractRequests() != value {
+		t.Errorf("ExtractRequests: value does not match")
+	}
+	value.Free()
+}
+
+func TestBaseLastError(t *testing.T) {
+	b := BaseLastError{}
+	str := "test error"
+	value := errors.New(str)
+
+	b.SetLastError(value)
+	if b.LastError() != value {
+		t.Errorf("LastError: value does not match")
+	}
+
+	b.LastErrorBuffer().Write(str)
+	if b.LastErrorBuffer().String() != str {
+		t.Errorf("LastErrorBuffer: expected %s, but found %s", str, b.LastErrorBuffer().String())
+	}
+	b.LastErrorBuffer().Free()
+}
+
+func TestBaseStringer(t *testing.T) {
+	b := BaseStringer{}
+	str := "test"
+
+	b.StringerBuffer().Write(str)
+	if b.StringerBuffer().String() != str {
+		t.Errorf("StringerBuffer: expected %s, but found %s", str, b.StringerBuffer().String())
+	}
+	b.StringerBuffer().Free()
+}
+
+func TestBaseProgress(t *testing.T) {
+	b := BaseProgress{}
+	str := "test"
+
+	b.ProgressBuffer().Write(str)
+	if b.ProgressBuffer().String() != str {
+		t.Errorf("ProgressBuffer: expected %s, but found %s", str, b.ProgressBuffer().String())
+	}
+	b.ProgressBuffer().Free()
+}

--- a/pkg/sdk/plugins/source/source_test.go
+++ b/pkg/sdk/plugins/source/source_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"io"
+	"testing"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"
+)
+
+type testPlugin struct {
+	plugins.BasePlugin
+}
+
+type testInstance struct {
+	BaseInstance
+}
+
+func (m *testPlugin) Info() *plugins.Info {
+	return &plugins.Info{
+		ID:                 999,
+		Name:               "test",
+		Description:        "Source Test",
+		Contact:            "",
+		Version:            "",
+		RequiredAPIVersion: "",
+		EventSource:        "test",
+	}
+}
+
+func (m *testPlugin) Init(config string) error {
+	return nil
+}
+
+func (m *testPlugin) Open(params string) (Instance, error) {
+	return &testInstance{}, nil
+}
+
+func (m *testPlugin) String(in io.ReadSeeker) (string, error) {
+	return "", nil
+}
+
+func (m *testInstance) NextBatch(pState sdk.PluginState, evts sdk.EventWriters) (int, error) {
+	return 0, nil
+}
+
+func assertPanic(t *testing.T, fun func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	fun()
+}
+
+func TestRegister(t *testing.T) {
+	registerFunc := func() {
+		Register(&testPlugin{})
+	}
+	registerFunc()
+	assertPanic(t, registerFunc)
+}

--- a/pkg/sdk/symbols/evtstr/evtstr_test.go
+++ b/pkg/sdk/symbols/evtstr/evtstr_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evtstr
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+var errDataMatch = errors.New("data does not match")
+var errTest = errors.New("test err")
+var strSuccess = "success"
+
+type sampleEvtStr struct {
+	strBuf       ptr.StringBuffer
+	shouldError  bool
+	expectedData []byte
+}
+
+func (s *sampleEvtStr) StringerBuffer() sdk.StringBuffer {
+	return &s.strBuf
+}
+
+func (s *sampleEvtStr) String(in io.ReadSeeker) (string, error) {
+	if s.shouldError {
+		return "", errTest
+	}
+	data, err := ioutil.ReadAll(in)
+	if err != nil {
+		return "", err
+	}
+	if !bytes.Equal(s.expectedData, data) {
+		return "", errDataMatch
+	}
+
+	return strSuccess, nil
+}
+
+func TestEvtStr(t *testing.T) {
+	sample := &sampleEvtStr{}
+	defer sample.StringerBuffer().Free()
+	handle := cgo.NewHandle(sample)
+	defer handle.Delete()
+
+	data := []byte{0, 1, 2, 3, 4, 5, 6}
+	sample.expectedData = data
+
+	// test success
+	cStr := plugin_event_to_string(_Ctype_uintptr_t(handle), (*_Ctype_uint8_t)(&data[0]), uint32(len(data)))
+	str := ptr.GoString(unsafe.Pointer(cStr))
+	if str != strSuccess {
+		t.Errorf("expected %s, but found %s", strSuccess, str)
+	}
+
+	// test forced error
+	sample.shouldError = true
+	cStr = plugin_event_to_string(_Ctype_uintptr_t(handle), (*_Ctype_uint8_t)(&data[0]), uint32(len(data)))
+	str = ptr.GoString(unsafe.Pointer(cStr))
+	if str != errTest.Error() {
+		t.Errorf("expected %s, but found %s", strSuccess, str)
+	}
+}

--- a/pkg/sdk/symbols/extract/extract.go
+++ b/pkg/sdk/symbols/extract/extract.go
@@ -42,7 +42,6 @@ import (
 func plugin_extract_fields_sync(plgState C.uintptr_t, evt *C.ss_plugin_event, numFields uint32, fields *C.ss_plugin_extract_field) int32 {
 	pHandle := cgo.Handle(plgState)
 	extract := pHandle.Value().(sdk.Extractor)
-	event := (*C.struct_ss_plugin_event)(evt)
 	extrReqs := pHandle.Value().(sdk.ExtractRequests)
 
 	// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
@@ -54,7 +53,7 @@ func plugin_extract_fields_sync(plgState C.uintptr_t, evt *C.ss_plugin_event, nu
 		extrReq = extrReqs.ExtractRequests().Get(int(flds[i].field_id))
 		extrReq.SetPtr(unsafe.Pointer(&flds[i]))
 
-		err := extract.Extract(extrReq, sdk.NewEventReader(unsafe.Pointer(event)))
+		err := extract.Extract(extrReq, sdk.NewEventReader(unsafe.Pointer(evt)))
 		if err != nil {
 			pHandle.Value().(sdk.LastError).SetLastError(err)
 			return sdk.SSPluginFailure

--- a/pkg/sdk/symbols/extract/extract_test.go
+++ b/pkg/sdk/symbols/extract/extract_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extract
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+var errTest = errors.New("testErr")
+
+type sampleExtract struct {
+	reqs    sdk.ExtractRequestPool
+	err     error
+	lastErr error
+}
+
+func (s *sampleExtract) ExtractRequests() sdk.ExtractRequestPool {
+	return s.reqs
+}
+
+func (s *sampleExtract) SetExtractRequests(reqs sdk.ExtractRequestPool) {
+	s.reqs = reqs
+}
+
+func (s *sampleExtract) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
+	return s.err
+}
+
+func (s *sampleExtract) SetLastError(err error) {
+	s.lastErr = err
+}
+
+func (s *sampleExtract) LastError() error {
+	return s.lastErr
+}
+
+func allocSSPluginExtractField(fid, ftype uint32, fname, farg string) (*_Ctype_ss_plugin_extract_field, func()) {
+	ret := &_Ctype_ss_plugin_extract_field{}
+	ret.field_id = _Ctype_uint(fid)
+	ret.ftype = _Ctype_uint(ftype)
+
+	argBuf := ptr.StringBuffer{}
+	fnameBuf := ptr.StringBuffer{}
+	fnameBuf.Write(fname)
+	ret.field = (*_Ctype_char)(fnameBuf.CharPtr())
+	if len(farg) > 0 {
+		argBuf.Write(farg)
+		ret.arg = (*_Ctype_char)(argBuf.CharPtr())
+	} else {
+		ret.arg = nil
+	}
+
+	return ret, func() {
+		argBuf.Free()
+		fnameBuf.Free()
+	}
+}
+
+func allocSSPluginEvent(num, ts uint64, data []byte) (*_Ctype_struct_ss_plugin_event, func()) {
+	ret := &_Ctype_struct_ss_plugin_event{}
+	ret.evtnum = _Ctype_uint64_t(num)
+	ret.ts = _Ctype_uint64_t(ts)
+	ret.data = (*_Ctype_uint8_t)(&data[0])
+	ret.datalen = _Ctype_uint32_t(len(data))
+
+	return ret, func() {
+		// nothing to deallocate here
+	}
+}
+
+func assertPanic(t *testing.T, fun func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	fun()
+}
+
+func TestExtract(t *testing.T) {
+	var res int32
+	sample := &sampleExtract{}
+	handle := cgo.NewHandle(sample)
+	defer handle.Delete()
+	reqs := sdk.NewExtractRequestPool()
+	defer reqs.Free()
+	sample.reqs = reqs
+
+	// Alloc c structs
+	evtData := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	event, freeEvent := allocSSPluginEvent(1, uint64(time.Now().UnixNano()), evtData)
+	defer freeEvent()
+	field, freeField := allocSSPluginExtractField(1, sdk.ParamTypeUint64, "test.field", "")
+	defer freeField()
+
+	// panic
+	badHandle := cgo.NewHandle(1)
+	assertPanic(t, func() {
+		plugin_extract_fields_sync(_Ctype_uintptr_t(badHandle), event, 1, field)
+	})
+
+	// success
+	res = plugin_extract_fields_sync(_Ctype_uintptr_t(handle), event, 1, field)
+	if res != sdk.SSPluginSuccess {
+		t.Errorf("(res): expected %d, but found %d", sdk.SSPluginSuccess, res)
+	} else if sample.lastErr != nil {
+		t.Errorf("(lastErr): should be nil")
+	}
+
+	// error
+	sample.err = errTest
+	res = plugin_extract_fields_sync(_Ctype_uintptr_t(handle), event, 1, field)
+	if res != sdk.SSPluginFailure {
+		t.Errorf("(res): expected %d, but found %d", sdk.SSPluginFailure, res)
+	} else if sample.lastErr != errTest {
+		t.Errorf("(lastErr): expected %s, but found %s", errTest.Error(), sample.lastErr.Error())
+	}
+}

--- a/pkg/sdk/symbols/fields/fields_test.go
+++ b/pkg/sdk/symbols/fields/fields_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fields
+
+import (
+	"encoding/json"
+	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+var sampleFields = []sdk.FieldEntry{
+	{Type: "uint64", Name: "test.field", Display: "Test Field", Desc: "Test Field"},
+}
+
+func TestFields(t *testing.T) {
+	// Test get/set
+	if Fields() != nil {
+		t.Errorf("expected nil")
+	}
+	SetFields(sampleFields)
+	if len(Fields()) != len(sampleFields) {
+		t.Errorf("expected %d, but found %d", len(sampleFields), len(Fields()))
+	}
+	for i, f := range Fields() {
+		if f != sampleFields[i] {
+			t.Errorf("wrong sample at index %d", i)
+		}
+	}
+
+	// Test C symbol
+	b, err := json.Marshal(&sampleFields)
+	if err != nil {
+		t.Error(err)
+	}
+	cStr := plugin_get_fields()
+	str := ptr.GoString(unsafe.Pointer(cStr))
+	if str != string(b) {
+		t.Errorf("expected %s, but found %s", string(b), str)
+	}
+}

--- a/pkg/sdk/symbols/info/info.go
+++ b/pkg/sdk/symbols/info/info.go
@@ -141,5 +141,4 @@ func SetExtractEventSources(sources []string) {
 	} else {
 		pExtractEventSources.Write(string(b))
 	}
-
 }

--- a/pkg/sdk/symbols/info/info_test.go
+++ b/pkg/sdk/symbols/info/info_test.go
@@ -15,3 +15,100 @@ limitations under the License.
 */
 
 package info
+
+import (
+	"encoding/json"
+	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
+)
+
+var testStr = "test"
+var testU32 = uint32(1)
+var testStrSlice = []string{"hello", "world"}
+
+func TestInfo(t *testing.T) {
+	var resU32 uint32
+	var resStr string
+	var expectedStr string
+
+	SetId(testU32)
+	resU32 = plugin_get_id()
+	if resU32 != testU32 {
+		t.Errorf("(id) expected %d, but found %d", testU32, resU32)
+	}
+
+	SetType(testU32)
+	resU32 = plugin_get_type()
+	if resU32 != testU32 {
+		t.Errorf("(type) expected %d, but found %d", testU32, resU32)
+	}
+	resU32 = Type()
+	if resU32 != testU32 {
+		t.Errorf("(type) expected %d, but found %d", testU32, resU32)
+	}
+
+	SetName(testStr)
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_name()))
+	if resStr != testStr {
+		t.Errorf("(name) expected %s, but found %s", testStr, resStr)
+	}
+
+	SetDescription(testStr)
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_description()))
+	if resStr != testStr {
+		t.Errorf("(description) expected %s, but found %s", testStr, resStr)
+	}
+
+	SetContact(testStr)
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_contact()))
+	if resStr != testStr {
+		t.Errorf("(contact) expected %s, but found %s", testStr, resStr)
+	}
+
+	SetVersion(testStr)
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_version()))
+	if resStr != testStr {
+		t.Errorf("(version) expected %s, but found %s", testStr, resStr)
+	}
+
+	SetRequiredAPIVersion(testStr)
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_required_api_version()))
+	if resStr != testStr {
+		t.Errorf("(requiredApiVersion) expected %s, but found %s", testStr, resStr)
+	}
+
+	SetEventSource(testStr)
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_event_source()))
+	if resStr != testStr {
+		t.Errorf("(eventSource) expected %s, but found %s", testStr, resStr)
+	}
+
+	// extractEventSources: nil
+	expectedStr = "[]"
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_extract_event_sources()))
+	if resStr != expectedStr {
+		t.Errorf("(extractEventSources) expected %s, but found %s", testStr, resStr)
+	}
+
+	// extractEventSources: regular case (should output a json)
+	b, err := json.Marshal(testStrSlice)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedStr = string(b)
+	SetExtractEventSources(testStrSlice)
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_extract_event_sources()))
+	if resStr != expectedStr {
+		t.Errorf("(extractEventSources) expected %s, but found %s", testStr, resStr)
+	}
+
+	// extractEventSources: empty string
+	expectedStr = "[]"
+	SetExtractEventSources([]string{})
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_extract_event_sources()))
+	if resStr != expectedStr {
+		t.Errorf("(extractEventSources) expected %s, but found %s", testStr, resStr)
+	}
+}

--- a/pkg/sdk/symbols/initialize/initialize_test.go
+++ b/pkg/sdk/symbols/initialize/initialize_test.go
@@ -15,3 +15,112 @@ limitations under the License.
 */
 
 package initialize
+
+import (
+	"errors"
+	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+var errTest = errors.New("errTest")
+
+type sampleInitialize struct {
+	destroyCalled bool
+	baseInit
+	reqs        sdk.ExtractRequestPool
+	stringerBuf ptr.StringBuffer
+	progressBuf ptr.StringBuffer
+}
+
+func (s *sampleInitialize) ExtractRequests() sdk.ExtractRequestPool {
+	return s.reqs
+}
+
+func (s *sampleInitialize) SetExtractRequests(reqs sdk.ExtractRequestPool) {
+	s.reqs = reqs
+}
+
+func (s *sampleInitialize) StringerBuffer() sdk.StringBuffer {
+	return &s.stringerBuf
+}
+
+func (s *sampleInitialize) ProgressBuffer() sdk.StringBuffer {
+	return &s.progressBuf
+}
+
+func (s *sampleInitialize) Destroy() {
+	s.destroyCalled = true
+}
+
+func assertPanic(t *testing.T, fun func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	fun()
+}
+
+func TestInitialize(t *testing.T) {
+	var res int32
+	var handle cgo.Handle
+	var cStr ptr.StringBuffer
+	cStr.Write("cStr")
+
+	// panic
+	assertPanic(t, func() {
+		SetOnInit(nil)
+	})
+
+	// nil state
+	SetOnInit(func(config string) (sdk.PluginState, error) {
+		return nil, nil
+	})
+	handle = cgo.Handle(plugin_init((*_Ctype_char)(cStr.CharPtr()), &res))
+	if res != sdk.SSPluginSuccess {
+		t.Errorf("(res): expected %d, but found %d", sdk.SSPluginSuccess, res)
+	} else if handle.Value() != nil {
+		t.Errorf("(value): expected %d, but found %d", unsafe.Pointer(nil), handle.Value())
+	}
+	handle.Delete()
+
+	// error
+	SetOnInit(func(config string) (sdk.PluginState, error) {
+		return nil, errTest
+	})
+	handle = cgo.Handle(plugin_init((*_Ctype_char)(cStr.CharPtr()), &res))
+	if res != sdk.SSPluginFailure {
+		t.Errorf("(res): expected %d, but found %d", sdk.SSPluginFailure, res)
+	}
+	val, ok := handle.Value().(sdk.LastError)
+	if !ok {
+		t.Errorf("(value): should implement sdk.LastError")
+	} else if val.LastError() != errTest {
+		t.Errorf("(err): expected %s, but found %s", errTest.Error(), val.LastError().Error())
+	}
+	handle.Delete()
+
+	// success
+	state := &sampleInitialize{}
+	SetOnInit(func(config string) (sdk.PluginState, error) {
+		return state, nil
+	})
+	handle = cgo.Handle(plugin_init((*_Ctype_char)(cStr.CharPtr()), &res))
+	if res != sdk.SSPluginSuccess {
+		t.Errorf("(res): expected %d, but found %d", sdk.SSPluginSuccess, res)
+	} else if handle.Value() != state {
+		t.Errorf("(value): expected %d, but found %d", unsafe.Pointer(state), handle.Value())
+	} else if state.ExtractRequests() == nil {
+		t.Errorf("expected SetExtractRequests() to be called")
+	}
+
+	// destroy
+	plugin_destroy(_Ctype_uintptr_t(handle))
+	if !state.destroyCalled {
+		t.Errorf("expected Destroy() to be called")
+	}
+}

--- a/pkg/sdk/symbols/nextbatch/nextbatch_test.go
+++ b/pkg/sdk/symbols/nextbatch/nextbatch_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nextbatch
+
+import (
+	"errors"
+	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+var errTest = errors.New("testErr")
+
+type sampleNextBatch struct {
+	events  sdk.EventWriters
+	n       int
+	err     error
+	lastErr error
+}
+
+func (s *sampleNextBatch) Events() sdk.EventWriters {
+	return s.events
+}
+
+func (s *sampleNextBatch) SetEvents(evts sdk.EventWriters) {
+	s.events = evts
+}
+
+func (s *sampleNextBatch) NextBatch(pState sdk.PluginState, evts sdk.EventWriters) (int, error) {
+	return s.n, s.err
+}
+
+func (s *sampleNextBatch) SetLastError(err error) {
+	s.lastErr = err
+}
+
+func (s *sampleNextBatch) LastError() error {
+	return s.lastErr
+}
+
+func TestNextBatch(t *testing.T) {
+	sample := &sampleNextBatch{}
+	handle := cgo.NewHandle(sample)
+	defer handle.Delete()
+	events, err := sdk.NewEventWriters(10, 10)
+	if err != nil {
+		t.Error(err)
+	}
+	defer events.Free()
+	sample.events = events
+
+	// generic testing callback
+	doTest := func(name string, res int32, num uint32, ptr unsafe.Pointer, err error) {
+		var resNum uint32
+		var resPtr *_Ctype_ss_plugin_event
+		r := plugin_next_batch(_Ctype_uintptr_t(handle), _Ctype_uintptr_t(handle), &resNum, &resPtr)
+		if r != res {
+			t.Errorf("(%s - res): expected %d, but found %d", name, res, r)
+		} else if resNum != num {
+			t.Errorf("(%s - num): expected %d, but found %d", name, num, resNum)
+		} else if unsafe.Pointer(resPtr) != ptr {
+			t.Errorf("(%s - ptr): expected %d, but found %d", name, ptr, resPtr)
+		} else if sample.lastErr != err {
+			if sample.lastErr == nil && err != nil {
+				t.Errorf("(%s - err): should not be nil", name)
+			} else if err == nil {
+				t.Errorf("(%s - err): should be nil", name)
+			} else {
+				t.Errorf("(%s - err): expected %s, but found %s", name, err.Error(), sample.lastErr.Error())
+			}
+		}
+	}
+
+	// success
+	sample.n = 5
+	sample.err = nil
+	doTest("success", sdk.SSPluginSuccess, uint32(sample.n), events.ArrayPtr(), nil)
+
+	// timeout
+	sample.n = 5
+	sample.err = sdk.ErrTimeout
+	doTest("timeout", sdk.SSPluginTimeout, uint32(sample.n), events.ArrayPtr(), nil)
+
+	// eof
+	sample.n = 5
+	sample.err = sdk.ErrEOF
+	doTest("timeout", sdk.SSPluginEOF, uint32(sample.n), events.ArrayPtr(), nil)
+
+	// failure
+	sample.n = 0
+	sample.err = errTest
+	doTest("failure", sdk.SSPluginFailure, uint32(sample.n), nil, errTest)
+
+}

--- a/pkg/sdk/symbols/open/open_test.go
+++ b/pkg/sdk/symbols/open/open_test.go
@@ -15,3 +15,117 @@ limitations under the License.
 */
 
 package open
+
+import (
+	"errors"
+	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+var errTest = errors.New("errTest")
+
+type sampleOpen struct {
+	lastErr error
+}
+
+func (b *sampleOpen) LastError() error {
+	return b.lastErr
+}
+
+func (b *sampleOpen) SetLastError(err error) {
+	b.lastErr = err
+}
+
+type sampleOpenInstance struct {
+	closeCalled bool
+	events      sdk.EventWriters
+}
+
+func (s *sampleOpenInstance) Events() sdk.EventWriters {
+	return s.events
+}
+
+func (s *sampleOpenInstance) SetEvents(evts sdk.EventWriters) {
+	s.events = evts
+}
+
+func (s *sampleOpenInstance) Close() {
+	s.closeCalled = true
+}
+
+func assertPanic(t *testing.T, fun func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	fun()
+}
+
+func TestInitialize(t *testing.T) {
+	var res int32
+	var pHandle cgo.Handle
+	var iHandle cgo.Handle
+	var cStr ptr.StringBuffer
+
+	// panics
+	assertPanic(t, func() {
+		SetOnOpen(nil)
+	})
+	assertPanic(t, func() {
+		plugin_open((_Ctype_uintptr_t)(pHandle), (*_Ctype_char)(cStr.CharPtr()), &res)
+	})
+
+	// initilize
+	pState := &sampleOpen{}
+	pHandle = cgo.NewHandle(pState)
+	cStr.Write("cStr")
+
+	// nil state
+	SetOnOpen(func(config string) (sdk.InstanceState, error) {
+		return nil, nil
+	})
+	iHandle = cgo.Handle(plugin_open((_Ctype_uintptr_t)(pHandle), (*_Ctype_char)(cStr.CharPtr()), &res))
+	if res != sdk.SSPluginSuccess {
+		t.Errorf("(res): expected %d, but found %d", sdk.SSPluginSuccess, res)
+	} else if iHandle.Value() != nil {
+		t.Errorf("(value): expected %d, but found %d", unsafe.Pointer(nil), iHandle.Value())
+	}
+	iHandle.Delete()
+
+	// error
+	SetOnOpen(func(config string) (sdk.InstanceState, error) {
+		return nil, errTest
+	})
+	iHandle = cgo.Handle(plugin_open((_Ctype_uintptr_t)(pHandle), (*_Ctype_char)(cStr.CharPtr()), &res))
+	if res != sdk.SSPluginFailure {
+		t.Errorf("(res): expected %d, but found %d", sdk.SSPluginFailure, res)
+	} else if pState.LastError() != errTest {
+		t.Errorf("(err): expected %s, but found %s", errTest.Error(), pState.LastError().Error())
+	}
+
+	// success
+	iState := &sampleOpenInstance{}
+	SetOnOpen(func(config string) (sdk.InstanceState, error) {
+		return iState, nil
+	})
+	iHandle = cgo.Handle(plugin_open((_Ctype_uintptr_t)(pHandle), (*_Ctype_char)(cStr.CharPtr()), &res))
+	if res != sdk.SSPluginSuccess {
+		t.Errorf("(res): expected %d, but found %d", sdk.SSPluginSuccess, res)
+	} else if iHandle.Value() != iState {
+		t.Errorf("(value): expected %d, but found %d", unsafe.Pointer(iState), iHandle.Value())
+	} else if iState.Events() == nil {
+		t.Errorf("expected SetEvents() to be called")
+	}
+
+	// close
+	plugin_close(_Ctype_uintptr_t(pHandle), _Ctype_uintptr_t(iHandle))
+	if !iState.closeCalled {
+		t.Errorf("expected Close() to be called")
+	}
+	pHandle.Delete()
+}

--- a/pkg/sdk/symbols/progress/progress_test.go
+++ b/pkg/sdk/symbols/progress/progress_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package progress
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+var testPct = float64(0.45)
+
+type sampleProgress struct {
+	strBuf ptr.StringBuffer
+	pct    float64
+}
+
+func (s *sampleProgress) ProgressBuffer() sdk.StringBuffer {
+	return &s.strBuf
+}
+
+func formatPercent(pct float64) string {
+	return fmt.Sprintf("%.2f", pct*100)
+}
+
+func (s *sampleProgress) Progress(pState sdk.PluginState) (float64, string) {
+	return s.pct, formatPercent(s.pct)
+}
+
+func assertPanic(t *testing.T, fun func()) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+		}
+	}()
+	fun()
+}
+
+func TestProgress(t *testing.T) {
+	var resPct uint32
+	var resStr string
+	var expectedStr string
+
+	sample := &sampleProgress{}
+	defer sample.ProgressBuffer().Free()
+	pHandle := cgo.NewHandle(1)
+	iHandle := cgo.NewHandle(sample)
+	defer pHandle.Delete()
+	defer iHandle.Delete()
+
+	// test success
+	sample.pct = testPct
+	expectedStr = formatPercent(testPct)
+	resStr = ptr.GoString(unsafe.Pointer(plugin_get_progress(_Ctype_uintptr_t(pHandle), _Ctype_uintptr_t(iHandle), &resPct)))
+	if resStr != expectedStr {
+		t.Errorf("expected %s, but found %s", expectedStr, resStr)
+	}
+	if resPct != uint32(testPct*10000) {
+		t.Errorf("expected %d, but found %d", uint32(testPct*10000), resPct)
+	}
+}
+
+func TestProgressPanic(t *testing.T) {
+	var resPct uint32
+	handle := cgo.NewHandle(int64(0))
+	defer handle.Delete()
+	assertPanic(t, func() {
+		plugin_get_progress(_Ctype_uintptr_t(handle), _Ctype_uintptr_t(handle), &resPct)
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

/area tests

**What this PR does / why we need it**:
This adds a bunch of unit tests in every package of the SDK. The prebuilt C symbols of the plugin framework are tested as well. This can be a valuable regression testing tool for future SDK updates.

Thanks to the new test suite, a miro bug has also been fixed in the `ptr` package.

The new coverage results are reported below:
```
$ make test
ok      github.com/falcosecurity/plugin-sdk-go/pkg/cgo  (cached)        coverage: 86.7% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/ptr  (cached)        coverage: 97.2% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk  0.019s  coverage: 90.5% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins  0.003s  coverage: 100.0% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins/extractor        0.014s  coverage: 90.0% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins/source   0.016s  coverage: 83.3% of statements
?       github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols  [no test files]
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/evtstr   0.003s  coverage: 90.0% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/extract  0.002s  coverage: 39.5% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/fields   0.006s  coverage: 85.7% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/info     (cached)        coverage: 96.0% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/initialize       (cached)        coverage: 96.9% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/lasterr  (cached)        coverage: 88.9% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/nextbatch        0.002s  coverage: 100.0% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/open     (cached)        coverage: 100.0% of statements
ok      github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/progress 0.003s  coverage: 77.8% of statements
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This PR misses a way for effectively test async extraction. I left a `todo` for the future, as I think this is a minor issue for now.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
