### PR TITLE
Use uint64_t to prevent long/longlong confusion

### DIFF
--- a/pkg/sdk/event.go
+++ b/pkg/sdk/event.go
@@ -170,7 +170,7 @@ type eventWriter struct {
 
 func newEventWriter(evtPtr unsafe.Pointer, dataSize int64) (*eventWriter, error) {
 	evt := (*C.ss_plugin_event)(evtPtr)
-	evt.ts = C.ulong(C.UINT64_MAX)
+	evt.ts = C.uint64_t(C.UINT64_MAX)
 	evt.data = (*C.uchar)(C.malloc(C.size_t(dataSize)))
 	evt.datalen = 0
 	brw, err := ptr.NewBytesReadWriter(unsafe.Pointer(evt.data), int64(dataSize), int64(dataSize))
@@ -203,7 +203,7 @@ func (p *eventWriter) Write(data []byte) (n int, err error) {
 }
 
 func (p *eventWriter) SetTimestamp(value uint64) {
-	(*C.ss_plugin_event)(p.ssPluginEvt).ts = C.ulong(value)
+	(*C.ss_plugin_event)(p.ssPluginEvt).ts = C.uint64_t(value)
 }
 
 func (p *eventWriter) free() {

--- a/pkg/sdk/extract.go
+++ b/pkg/sdk/extract.go
@@ -130,7 +130,7 @@ func (e *extractRequest) Arg() string {
 func (e *extractRequest) SetValue(v interface{}) {
 	switch e.FieldType() {
 	case ParamTypeUint64:
-		e.req.res_u64 = (C.ulong)(v.(uint64))
+		e.req.res_u64 = (C.uint64_t)(v.(uint64))
 	case ParamTypeCharBuf:
 		e.strBuf.Write(v.(string))
 		e.req.res_str = (*C.char)(e.strBuf.CharPtr())


### PR DESCRIPTION
Signed-off-by: Luca Guerra <luca@guerra.sh>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When attempting to compile a plugin on MacOS the process will fail because of an error like `../../../../go/pkg/mod/github.com/falcosecurity/plugin-sdk-go@v0.0.0-20211105150954-f1111dfdc937/pkg/sdk/event.go:173:9: cannot use _Ctype_ulong(_Ciconst_UINT64_MAX) (type _Ctype_ulong) as type _Ctype_ulonglong in assignment`
If you change that as the error suggests, you'll get the opposite error on Linux. This fixes the behavior by mapping those `uint64_t` fields to the `C.uint64_t` type.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
fix(sdk): fixed _Ctype_ulong / _Ctype_ulonglong assignment errors when trying to compile on MacOS
```
