### PR TITLE
refactor: improve async extraction with automatic activation and benchmarks

### DIFF
--- a/pkg/sdk/internal/hooks/hooks.go
+++ b/pkg/sdk/internal/hooks/hooks.go
@@ -1,0 +1,43 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hooks contains a set of init/destroy related hooks to meant
+// to be used internally in the SDK.
+package hooks
+
+import (
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
+)
+
+// OnDestroyFn is a callback used in plugin_destroy.
+type OnDestroyFn func(handle cgo.Handle)
+
+var onDestroy OnDestroyFn = func(cgo.Handle) {}
+
+// SetOnDestroy sets an deinitialization callback to be called in plugin_destroy to
+// release some resources the plugin state.
+func SetOnDestroy(fn OnDestroyFn) {
+	if fn == nil {
+		panic("plugin-sdk-go/sdk/symbols/initialize.SetOnDestroy: fn must not be nil")
+	}
+	onDestroy = fn
+}
+
+// OnDestroy returns the currently set deinitialization callback to
+// be called in plugin_destroy
+func OnDestroy() OnDestroyFn {
+	return onDestroy
+}

--- a/pkg/sdk/plugins/extractor/extractor.go
+++ b/pkg/sdk/plugins/extractor/extractor.go
@@ -19,9 +19,11 @@ limitations under the License.
 package extractor
 
 import (
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/internal/hooks"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"
-	_ "github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/extract"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/extract"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/fields"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/info"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/initialize"
@@ -78,7 +80,12 @@ func Register(p Plugin) {
 
 	initialize.SetOnInit(func(c string) (sdk.PluginState, error) {
 		err := p.Init(c)
+		extract.StartAsync()
 		return p, err
+	})
+
+	hooks.SetOnDestroy(func(handle cgo.Handle) {
+		extract.StopAsync()
 	})
 
 	registered = true

--- a/pkg/sdk/symbols/extract/async.go
+++ b/pkg/sdk/symbols/extract/async.go
@@ -88,6 +88,7 @@ func StartAsync() {
 	}
 
 	asyncCtx = C.async_init()
+	atomic.StoreInt32((*int32)(&asyncCtx.lock), state_wait)
 	go func() {
 		lock := (*int32)(&asyncCtx.lock)
 		waitStartTime := time.Now().Nanosecond()

--- a/pkg/sdk/symbols/extract/extract.c
+++ b/pkg/sdk/symbols/extract/extract.c
@@ -20,182 +20,68 @@ limitations under the License.
 #include <sys/time.h>
 #include "extract.h"
 
-enum async_extractor_state
+enum worker_state
 {
-	INIT = 0,
-	INPUT_READY = 1,
-	PROCESSING = 2,
-	DONE = 3,
-	SHUTDOWN_REQ = 4,
-	SHUTDOWN_DONE = 5,
+	WAIT = 0,
+	DATA_REQ = 1,
+	EXIT_REQ = 2,
+	EXIT_ACK = 3,
 };
 
 static async_extractor_info *s_async_extractor_ctx = NULL;
 
-// Source: https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.5/html_node/Elapsed-Time.html
-static int
-timeval_subtract (result, x, y)
-	struct timeval *result, *x, *y;
+async_extractor_info *async_init()
 {
-	/* Perform the carry for the later subtraction by updating y. */
-	if (x->tv_usec < y->tv_usec) {
-		int nsec = (y->tv_usec - x->tv_usec) / 1000000 + 1;
-		y->tv_usec -= 1000000 * nsec;
-		y->tv_sec += nsec;
-	}
-	if (x->tv_usec - y->tv_usec > 1000000) {
-		int nsec = (x->tv_usec - y->tv_usec) / 1000000;
-		y->tv_usec += 1000000 * nsec;
-		y->tv_sec -= nsec;
-	}
-
-	/* Compute the time remaining to wait.
-	   tv_usec is certainly positive. */
-	result->tv_sec = x->tv_sec - y->tv_sec;
-	result->tv_usec = x->tv_usec - y->tv_usec;
-
-	/* Return 1 if result is negative. */
-	return x->tv_sec < y->tv_sec;
-}
-
-bool async_extractor_wait(async_extractor_info *ainfo)
-{
-	atomic_store_explicit(&ainfo->lock, DONE, memory_order_seq_cst);
-	uint64_t ncycles = 0;
-	bool sleeping = false;
-
-	//
-	// Worker has done and now waits for a new input or a shutdown request.
-	// Note: we busy loop for the first 1ms to guarantee maximum performance.
-	//       After 1ms we start sleeping to conserve CPU.
-	//
-	enum async_extractor_state old_val = INPUT_READY;
-
-	struct timeval start_time;
-	gettimeofday(&start_time, NULL);
-
-	while(!atomic_compare_exchange_strong_explicit(&ainfo->lock, (int*) &old_val, PROCESSING, memory_order_seq_cst, memory_order_seq_cst))
-	{
-		// shutdown
-		if(old_val == SHUTDOWN_REQ)
-		{
-			atomic_store_explicit(&ainfo->lock, SHUTDOWN_DONE, memory_order_seq_cst);
-			return false;
-		}
-		old_val = INPUT_READY;
-
-		if(sleeping)
-		{
-			usleep(10000);
-		}
-		else
-		{
-			ncycles++;
-			if(ncycles >= 100000)
-			{
-				struct timeval cur_time, delta_time;
-				gettimeofday(&cur_time, NULL);
-				timeval_subtract(&delta_time, &cur_time, &start_time);
-				int delta_us = delta_time.tv_sec * 1000000 + delta_time.tv_usec;
-				if(delta_us > 1000)
-				{
-					sleeping = true;
-				}
-				else
-				{
-					ncycles = 0;
-				}
-			}
-		}
-	}
-	return true;
-}
-
-static void async_extractor_init(async_extractor_info *ainfo)
-{
-	atomic_store_explicit(&ainfo->lock, INIT, memory_order_seq_cst);
-}
-
-static void async_extractor_shutdown(async_extractor_info *ainfo)
-{
-	enum async_extractor_state old_val = DONE;
-	while (atomic_compare_exchange_strong_explicit(&ainfo->lock, (int*) &old_val, SHUTDOWN_REQ, memory_order_seq_cst, memory_order_seq_cst))
-	{
-		old_val = DONE;
-	}
-	
-	// await shutdown
-	while(atomic_load_explicit(&ainfo->lock, memory_order_seq_cst) != SHUTDOWN_DONE);
-}
-
-static int32_t async_extractor_extract_field(async_extractor_info *ainfo,
-					     const ss_plugin_event *evt,
-					     ss_plugin_extract_field *field)
-{
-	ainfo->evt = evt;
-	ainfo->field = field;
-
-	enum async_extractor_state old_val = DONE;
-	while (!atomic_compare_exchange_strong_explicit(&ainfo->lock, (int*) &old_val, INPUT_READY, memory_order_seq_cst, memory_order_seq_cst))
-	{
-		old_val = DONE;
-	}
-
-	//
-	// Once INPUT_READY state has been aquired, wait for worker completition
-	//
-	while(atomic_load_explicit(&ainfo->lock, memory_order_seq_cst) != DONE);
-
-	// rc now contains the error code for the extraction.
-	return ainfo->rc;
-}
-
-// Call this function to use async field extraction. In
-// plugin_destroy(), you *must* then call destroy_async_extractor.
-async_extractor_info * create_async_extractor()
-{
-	s_async_extractor_ctx = (async_extractor_info *) malloc(sizeof(async_extractor_info));
-	async_extractor_init(s_async_extractor_ctx);
-
+	s_async_extractor_ctx = (async_extractor_info *)malloc(sizeof(async_extractor_info));
 	return s_async_extractor_ctx;
 }
 
-void destroy_async_extractor()
+void async_deinit()
 {
-	async_extractor_shutdown(s_async_extractor_ctx);
 	free(s_async_extractor_ctx);
 	s_async_extractor_ctx = NULL;
 }
 
-// Defined in wrappers.go
+// Defined in extract.go
 extern int32_t plugin_extract_fields_sync(ss_plugin_t *s,
-			      const ss_plugin_event *evt,
-			      uint32_t num_fields,
-				  ss_plugin_extract_field *fields);
+										  const ss_plugin_event *evt,
+										  uint32_t num_fields,
+										  ss_plugin_extract_field *fields);
+
+static inline int32_t async_extract_request(ss_plugin_t *s,
+											const ss_plugin_event *evt,
+											uint32_t num_fields,
+											ss_plugin_extract_field *fields)
+{
+	// Since no concurrent requests are supported,
+	// we assume worker is already in WAIT state
+
+	// Set input data
+	s_async_extractor_ctx->s = s;
+	s_async_extractor_ctx->evt = evt;
+	s_async_extractor_ctx->num_fields = num_fields;
+	s_async_extractor_ctx->fields = fields;
+
+	// notify data request
+	atomic_store_explicit(&s_async_extractor_ctx->lock, DATA_REQ, memory_order_seq_cst);
+
+	// busy-wait until worker completation
+	while (atomic_load_explicit(&s_async_extractor_ctx->lock, memory_order_seq_cst) != WAIT);
+
+	return s_async_extractor_ctx->rc;
+}
 
 // This is the plugin API function. If s_async_extractor_ctx is
 // non-NULL, it calls the async extractor function. Otherwise, it
 // calls the synchronous extractor function.
 int32_t plugin_extract_fields(ss_plugin_t *s,
-			      const ss_plugin_event *evt,
-			      uint32_t num_fields,
-			      ss_plugin_extract_field *fields)
+							  const ss_plugin_event *evt,
+							  uint32_t num_fields,
+							  ss_plugin_extract_field *fields)
 {
-	int32_t rc;
-
-	if(s_async_extractor_ctx != NULL)
+	if (s_async_extractor_ctx != NULL)
 	{
-		for(uint32_t i = 0; i < num_fields; i++)
-		{
-			rc = async_extractor_extract_field(s_async_extractor_ctx, evt, &fields[i]);
-
-			if(rc != SS_PLUGIN_SUCCESS)
-			{
-				return rc;
-			}
-		}
-
-		return SS_PLUGIN_SUCCESS;
+		return async_extract_request(s, evt, num_fields, fields);
 	}
 
 	return plugin_extract_fields_sync(s, evt, num_fields, fields);

--- a/pkg/sdk/symbols/extract/extract.h
+++ b/pkg/sdk/symbols/extract/extract.h
@@ -21,14 +21,18 @@ limitations under the License.
 
 typedef struct async_extractor_info
 {
-	// Pointer as this allows swapping out events from other
-	// structs.
-	atomic_int lock;
+	// lock
+	atomic_int_least32_t lock;
+
+	// input data
+	ss_plugin_t *s;
 	const ss_plugin_event *evt;
-	ss_plugin_extract_field *field;
+	uint32_t num_fields;
+	ss_plugin_extract_field *fields;
+
+	// output data
 	int32_t rc;
 } async_extractor_info;
 
-async_extractor_info * create_async_extractor();
-void destroy_async_extractor();
-bool async_extractor_wait(async_extractor_info *ainfo);
+async_extractor_info *async_init();
+void async_deinit();

--- a/pkg/sdk/symbols/extract/internal/asyncbench/async.go
+++ b/pkg/sdk/symbols/extract/internal/asyncbench/async.go
@@ -1,0 +1,89 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package asyncbench
+
+import (
+	"sync/atomic"
+)
+
+/*
+#include "bench.h"
+*/
+import "C"
+
+func benchmark_async(lock *int32, n int) {
+	C.async_benchmark((*C.int32_t)(lock), C.int(n))
+}
+
+func benchmark_sync(n int, input int) {
+	C.sync_benchmark(C.int(n), C.int(input))
+}
+
+const (
+	state_wait = iota
+	state_data_req
+	state_exit_req
+	state_exit_ack
+)
+
+func startWorker(lock *int32) {
+	go func() {
+		for {
+			// Check for incoming request, if any, otherwise busy waits
+			switch atomic.LoadInt32(lock) {
+
+			case state_data_req:
+				// Incoming data request. Process it...
+				outData = doWork(inData)
+				// Processing done, return back to waiting state
+				atomic.StoreInt32(lock, state_wait)
+
+			case state_exit_req:
+				// Incoming exit request. Send ack and exit.
+				atomic.StoreInt32(lock, state_exit_ack)
+				return
+
+			default:
+				// busy wait
+			}
+		}
+	}()
+}
+
+func dataRequest(lock *int32) {
+	// We assume state_wait because no concurrent requests are supported
+	for !atomic.CompareAndSwapInt32(lock, state_wait, state_data_req) {
+		// spin
+	}
+
+	// state_data_req acquired, wait for worker completation
+	for atomic.LoadInt32(lock) != state_wait {
+		// spin
+	}
+}
+
+func exitRequest(lock *int32) {
+	// We assume state_wait because no concurrent requests are supported
+	for !atomic.CompareAndSwapInt32(lock, state_wait, state_exit_req) {
+		// spin
+	}
+
+	// state_exit_req acquired, wait for worker exiting
+	for atomic.LoadInt32(lock) != state_exit_ack {
+		// spin
+	}
+}

--- a/pkg/sdk/symbols/extract/internal/asyncbench/async_test.go
+++ b/pkg/sdk/symbols/extract/internal/asyncbench/async_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package asyncbench
+
+import (
+	"testing"
+)
+
+func TestWorker(t *testing.T) {
+	var lock int32
+	startWorker(&lock)
+
+	inData = testInput
+	dataRequest(&lock)
+	if outData != expectedOut {
+		t.Fatalf(`dataRequest failed: expected "%d", got "%d"`, expectedOut, outData)
+	}
+
+	exitRequest(&lock)
+}
+
+func BenchmarkCall_Go(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = doWork(testInput)
+	}
+}
+
+func BenchmarkCall_C_to_Go(b *testing.B) {
+	benchmark_sync(b.N, testInput)
+}
+
+func BenchmarkCall_Go_to_C(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = do_work_c(testInput)
+	}
+}
+
+func BenchmarkWorker_GoCaller(b *testing.B) {
+	var lock int32
+	startWorker(&lock)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dataRequest(&lock)
+	}
+	b.StopTimer()
+	exitRequest(&lock)
+}
+
+func BenchmarkWorker_CCaller(b *testing.B) {
+	var lock int32
+	startWorker(&lock)
+	b.ResetTimer()
+	benchmark_async(&lock, b.N)
+	b.StopTimer()
+	exitRequest(&lock)
+}

--- a/pkg/sdk/symbols/extract/internal/asyncbench/bench.c
+++ b/pkg/sdk/symbols/extract/internal/asyncbench/bench.c
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "bench.h"
+
+void data_request(atomic_int_least32_t *lock)
+{
+    // We assume state_wait because no concurrent requests are supported
+    enum worker_state old_val = WAIT;
+    while (!atomic_compare_exchange_strong_explicit(lock, (uint32_t *)&old_val, DATA_REQ, memory_order_seq_cst, memory_order_seq_cst))
+    {
+        old_val = WAIT;
+    }
+
+    // state_data_req acquired, wait for worker completation
+    while (atomic_load_explicit(lock, memory_order_seq_cst) != WAIT);
+}
+
+void async_benchmark(int32_t *lock, int n)
+{
+    for (int i = 0; i < n; i++)
+    {
+        data_request((atomic_int_least32_t *)lock);
+    }
+}
+
+// Defined in async.go
+extern int doWork(int);
+
+int sync_benchmark(int n, int input)
+{
+    int output;
+    for (int i = 0; i < n; i++)
+    {
+        output = doWork(input);
+    }
+    return output;
+}
+
+int do_work_c(int i)
+{
+    return i + 1;
+}

--- a/pkg/sdk/symbols/extract/internal/asyncbench/bench.h
+++ b/pkg/sdk/symbols/extract/internal/asyncbench/bench.h
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+enum worker_state
+{
+	WAIT = 0,
+	DATA_REQ = 1,
+	EXIT_REQ = 2,
+	EXIT_ACK = 3,
+};
+
+void data_request(atomic_int_least32_t *lock);
+
+void async_benchmark(int32_t *lock, int n);
+int sync_benchmark(int n, int input);
+
+int do_work_c(int i);

--- a/pkg/sdk/symbols/extract/internal/asyncbench/workload.go
+++ b/pkg/sdk/symbols/extract/internal/asyncbench/workload.go
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package asyncbench
+
+/*
+#include "bench.h"
+*/
+import "C"
+
+var inData, outData int
+
+var (
+	testInput   = 1
+	expectedOut = 2
+	badOut      = 3
+)
+
+//export doWork
+func doWork(input int) int {
+	return input + 1
+}
+
+func do_work_c(n int) int {
+	return int(C.do_work_c(C.int(n)))
+}

--- a/pkg/sdk/symbols/initialize/initialize.go
+++ b/pkg/sdk/symbols/initialize/initialize.go
@@ -46,6 +46,7 @@ import (
 	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/internal/hooks"
 )
 
 type baseInit struct {
@@ -107,6 +108,7 @@ func plugin_init(config *C.char, rc *int32) C.uintptr_t {
 func plugin_destroy(pState C.uintptr_t) {
 	if pState != 0 {
 		handle := cgo.Handle(pState)
+		hooks.OnDestroy()(handle)
 		if state, ok := handle.Value().(sdk.Destroyer); ok {
 			state.Destroy()
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:
For deeper context, see https://github.com/falcosecurity/plugin-sdk-go/issues/25. This PR improves async extraction by:
- Adding a reproducible benchmark suite, which helped us understanding how to improve the async worker
- Adding an automatic feasibility detection based on the number of CPUs. For now, async extraction is available if at least two CPUs are available.
- Enabling async extraction by default (if feasible), and allowing plugin developers to disable/enable it during the plugin initialization.
- Improving the async worker by using a shared spinlock between the C and Go runtimes. This avoids the need of a Go -> C call that was previously used to synchronize the worker.

**Which issue(s) this PR fixes**:

Fixes #25 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
refactor: improve async extraction with automatic activation and benchmarks
```