### PR TITLE
update: fix hook shodowing by refining event granularity

### DIFF
--- a/pkg/sdk/internal/hooks/hooks.go
+++ b/pkg/sdk/internal/hooks/hooks.go
@@ -14,30 +14,43 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package hooks contains a set of init/destroy related hooks to meant
-// to be used internally in the SDK.
+// Package hooks contains a set of hooks to be used internally in the SDK.
 package hooks
 
 import (
 	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
 )
 
-// OnDestroyFn is a callback used in plugin_destroy.
-type OnDestroyFn func(handle cgo.Handle)
+type OnBeforeDestroyFn func(handle cgo.Handle)
+type OnAfterInitFn func(handle cgo.Handle)
 
-var onDestroy OnDestroyFn = func(cgo.Handle) {}
+var (
+	onBeforeDestroy OnBeforeDestroyFn = func(cgo.Handle) {}
+	onAfterInit     OnAfterInitFn     = func(cgo.Handle) {}
+)
 
-// SetOnDestroy sets an deinitialization callback to be called in plugin_destroy to
-// release some resources the plugin state.
-func SetOnDestroy(fn OnDestroyFn) {
+// SetOnBeforeDestroy sets a callback that is invoked before the Destroy() method.
+func SetOnBeforeDestroy(fn OnBeforeDestroyFn) {
 	if fn == nil {
-		panic("plugin-sdk-go/sdk/symbols/initialize.SetOnDestroy: fn must not be nil")
+		panic("plugin-sdk-go/sdk/symbols/initialize.SetOnBeforeDestroy: fn must not be nil")
 	}
-	onDestroy = fn
+	onBeforeDestroy = fn
 }
 
-// OnDestroy returns the currently set deinitialization callback to
-// be called in plugin_destroy
-func OnDestroy() OnDestroyFn {
-	return onDestroy
+// OnBeforeDestroy returns a callback that is invoked before the Destroy() method.
+func OnBeforeDestroy() OnBeforeDestroyFn {
+	return onBeforeDestroy
+}
+
+// SetOnAfterInit sets a callback that is invoked after the Init() method.
+func SetOnAfterInit(fn OnAfterInitFn) {
+	if fn == nil {
+		panic("plugin-sdk-go/sdk/symbols/initialize.SetOnAfterInit: fn must not be nil")
+	}
+	onAfterInit = fn
+}
+
+// OnAfterInit returns a callback that is invoked after the Init() method.
+func OnAfterInit() OnAfterInitFn {
+	return onAfterInit
 }

--- a/pkg/sdk/plugins/extractor/extractor.go
+++ b/pkg/sdk/plugins/extractor/extractor.go
@@ -80,11 +80,14 @@ func Register(p Plugin) {
 
 	initialize.SetOnInit(func(c string) (sdk.PluginState, error) {
 		err := p.Init(c)
-		extract.StartAsync()
 		return p, err
 	})
 
-	hooks.SetOnDestroy(func(handle cgo.Handle) {
+	// setup hooks for automatically start/stop async extraction
+	hooks.SetOnAfterInit(func(handle cgo.Handle) {
+		extract.StartAsync()
+	})
+	hooks.SetOnBeforeDestroy(func(handle cgo.Handle) {
 		extract.StopAsync()
 	})
 

--- a/pkg/sdk/symbols/initialize/initialize.go
+++ b/pkg/sdk/symbols/initialize/initialize.go
@@ -101,14 +101,19 @@ func plugin_init(config *C.char, rc *int32) C.uintptr_t {
 		*rc = sdk.SSPluginSuccess
 	}
 
-	return (C.uintptr_t)(cgo.NewHandle(state))
+	handle := cgo.NewHandle(state)
+	if *rc == sdk.SSPluginSuccess {
+		hooks.OnAfterInit()(handle)
+	}
+
+	return (C.uintptr_t)(handle)
 }
 
 //export plugin_destroy
 func plugin_destroy(pState C.uintptr_t) {
 	if pState != 0 {
 		handle := cgo.Handle(pState)
-		hooks.OnDestroy()(handle)
+		hooks.OnBeforeDestroy()(handle)
 		if state, ok := handle.Value().(sdk.Destroyer); ok {
 			state.Destroy()
 		}


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

This fixes a bug that caused some internal hook calls to be shadowed. in the `extractor.Register` function, a callback to `extract.StartAsync` is set through the `initialize.SetOnInit` function. However, that may be overridden if `source.Register` is called after `extractor.Register`. This is currently reproducible in the `full` example. As for documentation, there should not be an ordering constraint for how the two `*.Register` functions are called.

This causes the `extract.StartAsync` function to potentially not being called. However, this `extract.StopAsync` is still called in any case, which causes a panic during the plugin destruction if the call to `extract.StartAsync` has been omitted.

This PR fixes this phenomena by refining the event granularity of the internal hooks. `OnDestroy` has been renamed to `OnBeforeDestroy`, and a new hook `OnAfterInit` has been introduced. The before/after pattern can be used in the future to add new hooks if necessary. Accordingly, `extract.StartAsync` is now called by the `OnAfterInit` hook, thus fixing the issue above.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update: fix hook shodowing by refining event granularity
```
