### PR TITLE
Allow field properties to be a list of strings

### DIFF
--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -112,5 +112,5 @@ type FieldEntry struct {
 	ArgRequired bool   `json:"argRequired"`
 	Display     string `json:"display"`
 	Desc        string `json:"desc"`
-	Properties  string `json:"properties"`
+	Properties  []string `json:"properties"`
 }

--- a/pkg/sdk/symbols/fields/fields_test.go
+++ b/pkg/sdk/symbols/fields/fields_test.go
@@ -19,6 +19,7 @@ package fields
 import (
 	"encoding/json"
 	"testing"
+	"reflect"
 	"unsafe"
 
 	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
@@ -39,7 +40,7 @@ func TestFields(t *testing.T) {
 		t.Errorf("expected %d, but found %d", len(sampleFields), len(Fields()))
 	}
 	for i, f := range Fields() {
-		if f != sampleFields[i] {
+		if ! reflect.DeepEqual(f, sampleFields[i]) {
 			t.Errorf("wrong sample at index %d", i)
 		}
 	}


### PR DESCRIPTION
Allow field properties to be a list of strings, to allow specifying
more than one property for a field.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
