### PR TITLE
fix(sdk/plugins/extractor): safely set async extractor stop hook

### DIFF
--- a/pkg/sdk/plugins/extractor/extractor.go
+++ b/pkg/sdk/plugins/extractor/extractor.go
@@ -86,9 +86,9 @@ func Register(p Plugin) {
 	// setup hooks for automatically start/stop async extraction
 	hooks.SetOnAfterInit(func(handle cgo.Handle) {
 		extract.StartAsync()
-	})
-	hooks.SetOnBeforeDestroy(func(handle cgo.Handle) {
-		extract.StopAsync()
+		hooks.SetOnBeforeDestroy(func(handle cgo.Handle) {
+			extract.StopAsync()
+		})
 	})
 
 	registered = true


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugin-sdk

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

In some edge cases, `extract.StopAsync` can could be invoked without `extract.StartAsync` being invoked first, which is semantically wrong (it also leads to a panic). This PR fixes this by setting up the `extract.StopAsync` callback only after `extract.StartAsync` is effectively invoked.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```