### PR TITLE
update: set default required api version

### DIFF
--- a/examples/extractor/extractor.go
+++ b/examples/extractor/extractor.go
@@ -58,7 +58,6 @@ func (m *MyPlugin) Info() *plugins.Info {
 		Description:         "An Extractor Plugin Example",
 		Contact:             "github.com/falcosecurity/plugin-sdk-go/",
 		Version:             "0.1.0",
-		RequiredAPIVersion:  "0.2.0",
 		ExtractEventSources: []string{"example"},
 	}
 }

--- a/examples/full/full.go
+++ b/examples/full/full.go
@@ -90,13 +90,12 @@ func init() {
 // This method is mandatory for source plugins.
 func (m *MyPlugin) Info() *plugins.Info {
 	return &plugins.Info{
-		ID:                 999,
-		Name:               "full-example",
-		Description:        "A Plugin Example for both Source and Extraction",
-		Contact:            "github.com/falcosecurity/plugin-sdk-go/",
-		Version:            "0.1.0",
-		RequiredAPIVersion: "0.2.0",
-		EventSource:        "example",
+		ID:          999,
+		Name:        "full-example",
+		Description: "A Plugin Example for both Source and Extraction",
+		Contact:     "github.com/falcosecurity/plugin-sdk-go/",
+		Version:     "0.1.0",
+		EventSource: "example",
 	}
 }
 

--- a/examples/full/go.mod
+++ b/examples/full/go.mod
@@ -5,6 +5,6 @@ replace github.com/falcosecurity/plugin-sdk-go => ../../
 go 1.15
 
 require (
-	github.com/alecthomas/jsonschema v0.0.0-20211228220459-151e3c21f49d // indirect
+	github.com/alecthomas/jsonschema v0.0.0-20211228220459-151e3c21f49d
 	github.com/falcosecurity/plugin-sdk-go v0.0.0-00010101000000-000000000000
 )

--- a/examples/full/go.sum
+++ b/examples/full/go.sum
@@ -1,0 +1,11 @@
+github.com/alecthomas/jsonschema v0.0.0-20211228220459-151e3c21f49d h1:4BQNwS4T13UU3Yee4GfzZH3Q9SNpKeJvLigfw8fDjX0=
+github.com/alecthomas/jsonschema v0.0.0-20211228220459-151e3c21f49d/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709 h1:Ko2LQMrRU+Oy/+EDBwX7eZ2jp3C47eDBB8EIhKTun+I=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/examples/source/source.go
+++ b/examples/source/source.go
@@ -73,13 +73,12 @@ func init() {
 // This method is mandatory for source plugins.
 func (m *MyPlugin) Info() *plugins.Info {
 	return &plugins.Info{
-		ID:                 999,
-		Name:               "source-example",
-		Description:        "A Source Plugin Example",
-		Contact:            "github.com/falcosecurity/plugin-sdk-go/",
-		Version:            "0.1.0",
-		RequiredAPIVersion: "0.2.0",
-		EventSource:        "example",
+		ID:          999,
+		Name:        "source-example",
+		Description: "A Source Plugin Example",
+		Contact:     "github.com/falcosecurity/plugin-sdk-go/",
+		Version:     "0.1.0",
+		EventSource: "example",
 	}
 }
 

--- a/pkg/sdk/symbols/info/info.c
+++ b/pkg/sdk/symbols/info/info.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sdk/symbols/info/info.c
+++ b/pkg/sdk/symbols/info/info.c
@@ -1,0 +1,23 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "info.h"
+#include "../../plugin_info.h"
+
+const char* get_default_required_api_version()
+{
+	return PLUGIN_API_VERSION_STR;
+}

--- a/pkg/sdk/symbols/info/info.go
+++ b/pkg/sdk/symbols/info/info.go
@@ -30,6 +30,9 @@ limitations under the License.
 // your plugin exports those symbols by other means.
 package info
 
+/*
+#include "info.h"
+*/
 import "C"
 import (
 	"encoding/json"
@@ -109,6 +112,9 @@ func SetVersion(version string) {
 
 //export plugin_get_required_api_version
 func plugin_get_required_api_version() *C.char {
+	if pRequiredAPIVersion.String() == "" {
+		return C.get_default_required_api_version()
+	}
 	return (*C.char)(pRequiredAPIVersion.CharPtr())
 }
 

--- a/pkg/sdk/symbols/info/info.h
+++ b/pkg/sdk/symbols/info/info.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sdk/symbols/info/info.h
+++ b/pkg/sdk/symbols/info/info.h
@@ -1,0 +1,19 @@
+/*
+Copyright (C) 2021 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+const char* get_default_required_api_version();


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

This supports a default value for `plugin_required_api_version` that removes the requirement of setting the `RequiredAPIVersion` info field for plugin developers. The value can still be specified to override the default one. The default value is grabbed from `plugin_info.h`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update: set default required api version
```
