### PR TITLE
update(sdk): divorce field type enumeration

### DIFF
--- a/pkg/sdk/extract.go
+++ b/pkg/sdk/extract.go
@@ -35,8 +35,8 @@ type ExtractRequest interface {
 	FieldID() uint64
 	//
 	// FieldType returns the type of the field for which the value extraction
-	// is requested. For now, only sdk.ParamTypeUint64 and
-	// sdk.ParamTypeCharBuf are supported.
+	// is requested. For now, only sdk.FieldTypeUint64 and
+	// sdk.FieldTypeCharBuf are supported.
 	FieldType() uint32
 	//
 	// Field returns the name of the field for which the value extraction
@@ -129,9 +129,9 @@ func (e *extractRequest) Arg() string {
 
 func (e *extractRequest) SetValue(v interface{}) {
 	switch e.FieldType() {
-	case ParamTypeUint64:
+	case FieldTypeUint64:
 		e.req.res_u64 = (C.uint64_t)(v.(uint64))
-	case ParamTypeCharBuf:
+	case FieldTypeCharBuf:
 		e.strBuf.Write(v.(string))
 		e.req.res_str = (*C.char)(e.strBuf.CharPtr())
 	default:

--- a/pkg/sdk/extract_test.go
+++ b/pkg/sdk/extract_test.go
@@ -59,9 +59,9 @@ func TestNewExtractRequestPool(t *testing.T) {
 	// Access should be non-contiguous
 	for i := 0; i < 20; i += 2 {
 		req := pool.Get(i)
-		cstruct, freeCStruct := allocSSPluginExtractField(5, ParamTypeUint64, "test.field", "arg")
+		cstruct, freeCStruct := allocSSPluginExtractField(5, FieldTypeUint64, "test.field", "arg")
 		req.SetPtr(unsafe.Pointer(cstruct))
-		if req.FieldType() != ParamTypeUint64 || req.FieldID() != 5 || req.Field() != "test.field" || req.Arg() != "arg" {
+		if req.FieldType() != FieldTypeUint64 || req.FieldID() != 5 || req.Field() != "test.field" || req.Arg() != "arg" {
 			println(req.FieldType(), ", ", req.FieldID(), ", ", req.Field(), ", ", req.Arg())
 			t.Errorf("could not read fields from sdk.ExtractRequest")
 		}
@@ -72,8 +72,8 @@ func TestNewExtractRequestPool(t *testing.T) {
 
 func TestExtractRequestSetValue(t *testing.T) {
 	pool := NewExtractRequestPool()
-	u64Ptr, freeU64Ptr := allocSSPluginExtractField(1, ParamTypeUint64, "test.u64", "")
-	strPtr, freeStrPtr := allocSSPluginExtractField(2, ParamTypeCharBuf, "test.str", "")
+	u64Ptr, freeU64Ptr := allocSSPluginExtractField(1, FieldTypeUint64, "test.u64", "")
+	strPtr, freeStrPtr := allocSSPluginExtractField(2, FieldTypeCharBuf, "test.str", "")
 	u64Req := pool.Get(0)
 	strReq := pool.Get(1)
 	u64Req.SetPtr(unsafe.Pointer(u64Ptr))

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -53,65 +53,21 @@ const DefaultEvtSize uint32 = 256 * 1024
 // interface used by the SDK.
 const DefaultBatchSize = 128
 
-// The full set of values that someday might be returned in the ftype
-// member of ss_plugin_extract_field structs. For now, only
-// ParamTypeUint64/ParamTypeCharBuf are used.
+// The full set of values that can be returned in the ftype
+// member of ss_plugin_extract_field structs.
 const (
-	ParamTypeNone             uint32 = 0
-	ParamTypeInt8             uint32 = 1
-	ParamTypeInt16            uint32 = 2
-	ParamTypeInt32            uint32 = 3
-	ParamTypeInt64            uint32 = 4
-	ParamTypeUintT8           uint32 = 5
-	ParamTypeUint16           uint32 = 6
-	ParamTypeUint32           uint32 = 7
-	ParamTypeUint64           uint32 = 8
-	ParamTypeCharBuf          uint32 = 9  // A printable buffer of bytes, NULL terminated
-	ParamTypeByteBuf          uint32 = 10 // A raw buffer of bytes not suitable for printing
-	ParamTypeErrno            uint32 = 11 // this is an INT64, but will be interpreted as an error code
-	ParamTypeSockaddr         uint32 = 12 // A sockaddr structure, 1byte family + data
-	ParamTypeSocktuple        uint32 = 13 // A sockaddr tuple,1byte family + 12byte data + 12byte data
-	ParamTypeFd               uint32 = 14 // An fd, 64bit
-	ParamTypePid              uint32 = 15 // A pid/tid, 64bit
-	ParamTypeFdlist           uint32 = 16 // A list of fds, 16bit count + count * (64bit fd + 16bit flags)
-	ParamTypeFspath           uint32 = 17 // A string containing a relative or absolute file system path, null terminated
-	ParamTypeSyscallId        uint32 = 18 // A 16bit system call ID. Can be used as a key for the g_syscall_info_table table.
-	ParamTypeSigYype          uint32 = 19 // An 8bit signal number
-	ParamTypeRelTime          uint32 = 20 // A relative time. Seconds * 10^9  + nanoseconds. 64bit.
-	ParamTypeAbsTime          uint32 = 21 // An absolute time interval. Seconds from epoch * 10^9  + nanoseconds. 64bit.
-	ParamTypePort             uint32 = 22 // A TCP/UDP prt. 2 bytes.
-	ParamTypeL4Proto          uint32 = 23 // A 1 byte IP protocol type.
-	ParamTypeSockfamily       uint32 = 24 // A 1 byte socket family.
-	ParamTypeBool             uint32 = 25 // A boolean value, 4 bytes.
-	ParamTypeIpv4Addr         uint32 = 26 // A 4 byte raw IPv4 address.
-	ParamTypeDyn              uint32 = 27 // Type can vary depending on the context. Used for filter fields like evt.rawarg.
-	ParamTypeFlags8           uint32 = 28 // this is an UINT8, but will be interpreted as 8 bit flags.
-	ParamTypeFlags16          uint32 = 29 // this is an UINT16, but will be interpreted as 16 bit flags.
-	ParamTypeFlags32          uint32 = 30 // this is an UINT32, but will be interpreted as 32 bit flags.
-	ParamTypeUid              uint32 = 31 // this is an UINT32, MAX_UINT32 will be interpreted as no value.
-	ParamTypeGid              uint32 = 32 // this is an UINT32, MAX_UINT32 will be interpreted as no value.
-	ParamTypeDouble           uint32 = 33 // this is a double precision floating point number.
-	ParamTypeSigSet           uint32 = 34 // sigset_t. I only store the lower UINT32 of it
-	ParamTypeCharBufArray     uint32 = 35 // Pointer to an array of strings, exported by the user events decoder. 64bit. For internal use only.
-	ParamTypeCharBufPairArray uint32 = 36 // Pointer to an array of string pairs, exported by the user events decoder. 64bit. For internal use only.
-	ParamTypeIpv4Net          uint32 = 37 // An IPv4 network.
-	ParamTypeIpv6Addr         uint32 = 38 // A 16 byte raw IPv6 address.
-	ParamTypeIpv6Net          uint32 = 39 // An IPv6 network.
-	ParamTypeIpAddr           uint32 = 40 // Either an IPv4 or IPv6 address. The length indicates which one it is.
-	ParamTypeIpNet            uint32 = 41 // Either an IPv4 or IPv6 network. The length indicates which one it is.
-	ParamTypeMode             uint32 = 42 // a 32 bit bitmask to represent file modes.
-	ParamTypeFsRelPath        uint32 = 43 // A path relative to a dirfd.
-	ParamTypeMax              uint32 = 44 // array size
+	FieldTypeUint64  uint32 = 8
+	FieldTypeCharBuf uint32 = 9 // A printable buffer of bytes, NULL terminated
 )
 
 // FieldEntry represents a single field entry that an extractor plugin can expose.
 // Should be used when implementing plugin_get_fields().
 type FieldEntry struct {
-	Type        string `json:"type"`
-	Name        string `json:"name"`
-	ArgRequired bool   `json:"argRequired"`
-	Display     string `json:"display"`
-	Desc        string `json:"desc"`
+	Type        string   `json:"type"`
+	Name        string   `json:"name"`
+	ArgRequired bool     `json:"argRequired"`
+	Display     string   `json:"display"`
+	Desc        string   `json:"desc"`
 	Properties  []string `json:"properties"`
 }
 

--- a/pkg/sdk/symbols/extract/extract_test.go
+++ b/pkg/sdk/symbols/extract/extract_test.go
@@ -110,7 +110,7 @@ func TestExtract(t *testing.T) {
 	evtData := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	event, freeEvent := allocSSPluginEvent(1, uint64(time.Now().UnixNano()), evtData)
 	defer freeEvent()
-	field, freeField := allocSSPluginExtractField(1, sdk.ParamTypeUint64, "test.field", "")
+	field, freeField := allocSSPluginExtractField(1, sdk.FieldTypeUint64, "test.field", "")
 	defer freeField()
 
 	// panic


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

/kind design

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

During the development of the plugin system, the enumeration of fields for field extraction has been divorced from the one used internally by libsinsp. In the SDK Go, the enum constants still reflect the enumeration in libsinsp. This is now changed to only respect the enumeration of the plugin framework.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(sdk): divorce field type enumeration
```
