### PR TITLE
update(sdk): Export plugin_extract_fields on Windows.

### DIFF
--- a/pkg/sdk/symbols/extract/extract.c
+++ b/pkg/sdk/symbols/extract/extract.c
@@ -20,6 +20,13 @@ limitations under the License.
 #include <sys/time.h>
 #include "extract.h"
 
+// Possibly oversimplified version of https://gcc.gnu.org/wiki/Visibility
+#if defined _WIN32 || defined __CYGWIN__
+#define FALCO_PLUGIN_SDK_PUBLIC __declspec(dllexport)
+#else
+#define FALCO_PLUGIN_SDK_PUBLIC
+#endif
+
 enum worker_state
 {
 	WAIT = 0,
@@ -74,7 +81,7 @@ static inline int32_t async_extract_request(ss_plugin_t *s,
 // This is the plugin API function. If s_async_extractor_ctx is
 // non-NULL, it calls the async extractor function. Otherwise, it
 // calls the synchronous extractor function.
-int32_t plugin_extract_fields(ss_plugin_t *s,
+FALCO_PLUGIN_SDK_PUBLIC int32_t plugin_extract_fields(ss_plugin_t *s,
 							  const ss_plugin_event *evt,
 							  uint32_t num_fields,
 							  ss_plugin_extract_field *fields)


### PR DESCRIPTION
Make sure we set the dllexport attribute on plugin_extract_fields when
we're building for Windows.

Signed-off-by: Gerald Combs <gerald@wireshark.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

It ensures that plugin_extract_fields is callable on Windows.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
