### PR TITLE
new(sdk/plugins): add builtin event stream instance implementations for push and pull models

### DIFF
--- a/examples/source/source.go
+++ b/examples/source/source.go
@@ -87,7 +87,7 @@ func (m *MyPlugin) Init(config string) error {
 // callback. This method is mandatory for the event sourcing capability.
 func (m *MyPlugin) Open(params string) (source.Instance, error) {
 	counter := 0
-	pull := func(ctx context.Context, ps sdk.PluginState, evt sdk.EventWriter) error {
+	pull := func(ctx context.Context, evt sdk.EventWriter) error {
 		counter++
 		if err := gob.NewEncoder(evt.Writer()).Encode(counter); err != nil {
 			return err

--- a/examples/source/source.go
+++ b/examples/source/source.go
@@ -82,11 +82,11 @@ func (m *MyPlugin) Init(config string) error {
 }
 
 // Open opens the plugin source and starts a new capture session (e.g. stream
-// of events). This uses the SDK built-in source.OpenPullInstance() function
+// of events). This uses the SDK built-in source.NewPullInstance() function
 // that allows creating an event source by simply providing a event-generating
 // callback. This method is mandatory for the event sourcing capability.
 func (m *MyPlugin) Open(params string) (source.Instance, error) {
-	counter := 0
+	counter := uint64(0)
 	pull := func(ctx context.Context, evt sdk.EventWriter) error {
 		counter++
 		if err := gob.NewEncoder(evt.Writer()).Encode(counter); err != nil {
@@ -95,7 +95,7 @@ func (m *MyPlugin) Open(params string) (source.Instance, error) {
 		evt.SetTimestamp(uint64(time.Now().UnixNano()))
 		return nil
 	}
-	return source.OpenPullInstance(pull)
+	return source.NewPullInstance(pull)
 }
 
 // String produces a string representation of an event data produced by the

--- a/pkg/sdk/event_test.go
+++ b/pkg/sdk/event_test.go
@@ -69,7 +69,7 @@ func BenchmarkEventWritersNext(b *testing.B) {
 }
 
 func BenchmarkEventWritersNextBatch(b *testing.B) {
-	writers, err := NewEventWriters(DefaultBatchSize, int64(DefaultEvtSize))
+	writers, err := NewEventWriters(int64(DefaultBatchSize), int64(DefaultEvtSize))
 	if err != nil {
 		println(err.Error())
 		b.Fail()
@@ -88,7 +88,7 @@ func BenchmarkEventWritersNextBatch(b *testing.B) {
 }
 
 func TestEventWritersNextBatch(t *testing.T) {
-	events, err := NewEventWriters(DefaultBatchSize, int64(DefaultEvtSize))
+	events, err := NewEventWriters(int64(DefaultBatchSize), int64(DefaultEvtSize))
 	if err != nil {
 		println(err.Error())
 		t.Fail()

--- a/pkg/sdk/inmemory.go
+++ b/pkg/sdk/inmemory.go
@@ -1,0 +1,149 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"bytes"
+	"io"
+	"unsafe"
+)
+
+// InMemoryExtractRequest is an in-memory implementation of
+// sdk.ExtractRequest that allows changing its internal values.
+type InMemoryExtractRequest struct {
+	ValFieldID    uint64
+	ValFieldType  uint32
+	ValField      string
+	ValArgKey     string
+	ValArgIndex   uint64
+	ValArgPresent bool
+	ValIsList     bool
+	ValValue      interface{}
+	ValPtr        unsafe.Pointer
+}
+
+func (i *InMemoryExtractRequest) FieldID() uint64 {
+	return i.ValFieldID
+}
+
+func (i *InMemoryExtractRequest) FieldType() uint32 {
+	return i.ValFieldType
+}
+
+func (i *InMemoryExtractRequest) Field() string {
+	return i.ValField
+}
+
+func (i *InMemoryExtractRequest) ArgKey() string {
+	return i.ValArgKey
+}
+
+func (i *InMemoryExtractRequest) ArgIndex() uint64 {
+	return i.ValArgIndex
+}
+
+func (i *InMemoryExtractRequest) ArgPresent() bool {
+	return i.ValArgPresent
+}
+
+func (i *InMemoryExtractRequest) IsList() bool {
+	return i.ValIsList
+}
+
+func (i *InMemoryExtractRequest) SetValue(v interface{}) {
+	i.ValValue = v
+}
+
+func (i *InMemoryExtractRequest) SetPtr(ptr unsafe.Pointer) {
+	i.ValPtr = ptr
+}
+
+// InMemoryExtractRequestPool is an in-memory implementation of
+// sdk.ExtractRequestPool that allows changing its internal values.
+type InMemoryExtractRequestPool struct {
+	Requests map[int]ExtractRequest
+}
+
+func (i *InMemoryExtractRequestPool) Get(requestIndex int) ExtractRequest {
+	return i.Requests[requestIndex]
+}
+
+func (i *InMemoryExtractRequest) Free() {
+	// do nothing
+}
+
+// InMemoryEventWriter is an in-memory implementation of
+// sdk.EventWriter that allows changing its internal values.
+type InMemoryEventWriter struct {
+	Buffer       bytes.Buffer
+	ValTimestamp uint64
+}
+
+func (i *InMemoryEventWriter) Writer() io.Writer {
+	i.Buffer.Reset()
+	return &i.Buffer
+}
+
+func (i *InMemoryEventWriter) SetTimestamp(value uint64) {
+	i.ValTimestamp = value
+}
+
+// InMemoryEventWriters is an in-memory implementation of
+// sdk.EventWriters that allows changing its internal values.
+type InMemoryEventWriters struct {
+	Writers     []EventWriter
+	ValArrayPtr unsafe.Pointer
+	OnFree      func()
+}
+
+func (i *InMemoryEventWriters) Get(eventIndex int) EventWriter {
+	return i.Writers[eventIndex]
+}
+
+func (i *InMemoryEventWriters) Len() int {
+	return len(i.Writers)
+}
+
+func (i *InMemoryEventWriters) ArrayPtr() unsafe.Pointer {
+	return i.ValArrayPtr
+}
+
+func (i *InMemoryEventWriters) Free() {
+	if i.OnFree != nil {
+		i.OnFree()
+	}
+}
+
+// InMemoryEventReader is an in-memory implementation of
+// sdk.EventReader that allows changing its internal values.
+type InMemoryEventReader struct {
+	Buffer       []byte
+	ValEventNum  uint64
+	ValTimestamp uint64
+}
+
+func (i *InMemoryEventReader) EventNum() uint64 {
+	return i.ValEventNum
+}
+
+func (i *InMemoryEventReader) Timestamp() uint64 {
+	return i.ValTimestamp
+}
+
+func (i *InMemoryEventReader) Reader() io.ReadSeeker {
+	return bytes.NewReader(i.Buffer)
+}

--- a/pkg/sdk/internal/sdk/inmemory.go
+++ b/pkg/sdk/internal/sdk/inmemory.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"io"
 	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
 )
 
 // InMemoryExtractRequest is an in-memory implementation of
@@ -75,10 +77,10 @@ func (i *InMemoryExtractRequest) SetPtr(ptr unsafe.Pointer) {
 // InMemoryExtractRequestPool is an in-memory implementation of
 // sdk.ExtractRequestPool that allows changing its internal values.
 type InMemoryExtractRequestPool struct {
-	Requests map[int]ExtractRequest
+	Requests map[int]sdk.ExtractRequest
 }
 
-func (i *InMemoryExtractRequestPool) Get(requestIndex int) ExtractRequest {
+func (i *InMemoryExtractRequestPool) Get(requestIndex int) sdk.ExtractRequest {
 	return i.Requests[requestIndex]
 }
 
@@ -105,12 +107,12 @@ func (i *InMemoryEventWriter) SetTimestamp(value uint64) {
 // InMemoryEventWriters is an in-memory implementation of
 // sdk.EventWriters that allows changing its internal values.
 type InMemoryEventWriters struct {
-	Writers     []EventWriter
+	Writers     []sdk.EventWriter
 	ValArrayPtr unsafe.Pointer
 	OnFree      func()
 }
 
-func (i *InMemoryEventWriters) Get(eventIndex int) EventWriter {
+func (i *InMemoryEventWriters) Get(eventIndex int) sdk.EventWriter {
 	return i.Writers[eventIndex]
 }
 

--- a/pkg/sdk/plugins/source/instance.go
+++ b/pkg/sdk/plugins/source/instance.go
@@ -121,7 +121,7 @@ type pullInstance struct {
 // The context passed-in to the pull function is cancelled automatically
 // when the framework invokes Close() on the event source, or when the
 // user-configured context is cancelled.
-func OpenPullInstance(pull PullFunc, options ...func(*builtinInstance)) (Instance, error) {
+func NewPullInstance(pull PullFunc, options ...func(*builtinInstance)) (Instance, error) {
 	res := &pullInstance{
 		pull: pull,
 		builtinInstance: builtinInstance{
@@ -207,7 +207,7 @@ type pushInstance struct {
 	evtC <-chan PushEvent
 }
 
-// OpenPushInstance opens a new event source and starts a capture session,
+// NewPushInstance opens a new event source and starts a capture session,
 // filling the event batches with a push model.
 //
 // In this model, events are produced through a channel in the form of
@@ -221,7 +221,7 @@ type pushInstance struct {
 // The opened event source can be manually closed by cancelling the optional
 // passed-in context, by closing the event cannel, or by sending
 // source.PushEvent containing a non-nil Err.
-func OpenPushInstance(evtC <-chan PushEvent, options ...func(*builtinInstance)) (Instance, error) {
+func NewPushInstance(evtC <-chan PushEvent, options ...func(*builtinInstance)) (Instance, error) {
 	res := &pushInstance{
 		evtC: evtC,
 		builtinInstance: builtinInstance{

--- a/pkg/sdk/plugins/source/instance.go
+++ b/pkg/sdk/plugins/source/instance.go
@@ -1,0 +1,298 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+var (
+	defaultInstanceTimeout = 30 * time.Millisecond
+)
+
+type builtinInstance struct {
+	BaseInstance
+	shutdown func()
+	ctx      context.Context
+	timeout  time.Duration
+}
+
+type pullInstance struct {
+	builtinInstance
+	eof           bool
+	pull          PullFunc
+	timeoutTicker *time.Ticker
+}
+
+type pushInstance struct {
+	builtinInstance
+	eof           bool
+	evtC          <-chan PushEvent
+	timeoutTicker *time.Ticker
+}
+
+// PullFunc produces a new event and returns a non-nil error in case of failure.
+//
+// The event data is produced through the sdk.EventWriter interface.
+// The sdk.PluginState argument is the state of the plugin for this the given
+// event source has been opened, and should be casted to its specific type.
+// The context argument can be used to check for termination signals, which
+// happen when the framework closes the event source or when the optional
+// context passed-in by the user gets cancelled.
+type PullFunc func(context.Context, sdk.PluginState, sdk.EventWriter) error
+
+// PushEvent represents an event produced from an event source with pull model.
+//
+// If the event source produced the event successfully, then Data must be non-nil
+// and Err must be ni. If the event source encountered a failure, Data must be
+// nil and Err should contain an error describing the failure.
+//
+// Timestamp can be optionally set to indicate a specific timestamp for the
+// produced event.
+type PushEvent struct {
+	Err       error
+	Data      []byte
+	Timestamp time.Time
+}
+
+// WithInstanceContext sets a custom context in the opened event source.
+// If the context is cancelled, the event source is closed and sdk.ErrEOF
+// is returned by the current invocation of NextBatch() and by any subsequent
+// invocation.
+func WithInstanceContext(ctx context.Context) func(*builtinInstance) {
+	return func(s *builtinInstance) {
+		s.ctx = ctx
+	}
+}
+
+// WithInstanceTimeout sets a custom timeout in the opened event source.
+// When the timeout is reached, the current invocation of NextBatch() returns
+// sdk.ErrTimeout.
+func WithInstanceTimeout(timeout time.Duration) func(*builtinInstance) {
+	return func(s *builtinInstance) {
+		s.timeout = timeout
+	}
+}
+
+// WithInstanceClose sets a custom closing callback in the opened event source.
+// The passed-in function is invoked when the event source gets closed.
+func WithInstanceClose(close func()) func(*builtinInstance) {
+	return func(s *builtinInstance) {
+		s.shutdown = close
+	}
+}
+
+func (s *pullInstance) NextBatch(pState sdk.PluginState, evts sdk.EventWriters) (n int, err error) {
+	// once EOF has been hit, we should return it at each new call of NextBatch
+	if s.eof {
+		return 0, sdk.ErrEOF
+	}
+
+	// timeout needs to be resetted for this batch
+	s.timeoutTicker.Reset(s.timeout)
+
+	// attempt filling the event batch
+	n = 0
+	for n < evts.Len() {
+		// check if we should return before pulling another event
+		select {
+		// timeout hits, so we flush a partial batch
+		case <-s.timeoutTicker.C:
+			return n, sdk.ErrTimeout
+		// context has been canceled, so we exit
+		case <-s.ctx.Done():
+			s.eof = true
+			return n, sdk.ErrEOF
+		default:
+		}
+
+		// pull a new event
+		if err = s.pull(s.ctx, pState, evts.Get(n)); err != nil {
+			return
+		}
+		n++
+	}
+
+	// return a full batch
+	return n, nil
+}
+
+func (s *pullInstance) Close() {
+	// this cancels the context and calls the optional callback
+	s.shutdown()
+
+	// stop timeout ticker
+	s.timeoutTicker.Stop()
+}
+
+// NewPullInstance opens a new event source and starts a capture session,
+// filling the event batches with a pull model.
+//
+// The PullFunc required argument is a function that creates a new event and
+// returns a non-nil error in case of success. The returned source.Instance
+// provides a pre-built implementation of NextBatch() that correctly handles
+// termination and timeouts. This should be used by developers to open an event
+// source without defining a new type and by using a functional design.
+//
+// The pull function is invoked sequentially and is blocking for the event
+// source, meaning that it must not be a suspensive function. This implies
+// avoiding suspending an execution through a select or through synchronization
+// primitives.
+//
+// Users can pass option parameters to influence the behavior of the opened
+// event source, such as passing a context or setting a custom timeout duration.
+//
+// The context passed-in to the pull function is cancelled automatically
+// when the framework invokes Close() on the event source, or when the
+// user-configured context is cancelled.
+func OpenPullInstance(pull PullFunc, options ...func(*builtinInstance)) (Instance, error) {
+	res := &pullInstance{
+		eof:  false,
+		pull: pull,
+		builtinInstance: builtinInstance{
+			ctx:      context.Background(),
+			timeout:  defaultInstanceTimeout,
+			shutdown: func() {},
+		},
+	}
+
+	// apply options
+	for _, opt := range options {
+		opt(&res.builtinInstance)
+	}
+
+	// init timer
+	res.timeoutTicker = time.NewTicker(res.timeout)
+
+	// setup internally-cancellable context
+	prevCancel := res.shutdown
+	cancelableCtx, cancelCtx := context.WithCancel(res.ctx)
+	res.ctx = cancelableCtx
+	res.shutdown = func() {
+		cancelCtx()
+		prevCancel()
+	}
+
+	// return opened instance
+	return res, nil
+}
+
+func (s *pushInstance) NextBatch(pState sdk.PluginState, evts sdk.EventWriters) (int, error) {
+	// once EOF has been hit, we should return it at each new call of NextBatch
+	if s.eof {
+		return 0, sdk.ErrEOF
+	}
+
+	// timeout needs to be resetted for this batch
+	s.timeoutTicker.Reset(s.timeout)
+
+	// attempt filling the event batch
+	n := 0
+	for n < evts.Len() {
+		select {
+		// an event is received, so we add it in the batch
+		case evt, ok := <-s.evtC:
+			// event channel is closed, we reached EOF
+			if !ok {
+				evt.Err = sdk.ErrEOF
+			}
+			// if there are no errors so far, try writing the event
+			if evt.Err == nil {
+				if l, wErr := evts.Get(n).Writer().Write(evt.Data); wErr != nil {
+					evt.Err = wErr
+				} else if l < len(evt.Data) {
+					evt.Err = io.ErrShortWrite
+				}
+			}
+			// an error occurred, so we need to exit
+			if evt.Err != nil {
+				s.eof = true
+				return n, evt.Err
+			}
+			// event added to the batch successfully
+			if !evt.Timestamp.IsZero() {
+				evts.Get(n).SetTimestamp(uint64(evt.Timestamp.UnixNano()))
+			}
+			n++
+		// timeout hits, so we flush a partial batch
+		case <-s.timeoutTicker.C:
+			return n, sdk.ErrTimeout
+		// context has been canceled, so we exit
+		case <-s.ctx.Done():
+			s.eof = true
+			return n, sdk.ErrEOF
+		}
+	}
+	return n, nil
+}
+
+func (s *pushInstance) Close() {
+	// this cancels the context and calls the optional callback
+	s.shutdown()
+
+	// stop timeout ticker
+	s.timeoutTicker.Stop()
+}
+
+// OpenPushInstance opens a new event source and starts a capture session,
+// filling the event batches with a push model.
+//
+// In this model, events are produced through a channel in the form of
+// source.PushEvent messages. This is suitable for cases in which event
+// production is suspensive, meaning that the time elapsed waiting for a
+// new event to be produced is not deterministic or has no guaranteed limit.
+//
+// Users can pass option parameters to influence the behavior of the opened
+// event source, such as passing a context or setting a custom timeout duration.
+//
+// The opened event source can be manually closed by cancelling the optional
+// passed-in context, by closing the event cannel, or by sending
+// source.PushEvent containing a non-nil Err.
+func OpenPushInstance(evtC <-chan PushEvent, options ...func(*builtinInstance)) (Instance, error) {
+	res := &pushInstance{
+		eof:  false,
+		evtC: evtC,
+		builtinInstance: builtinInstance{
+			ctx:      context.Background(),
+			timeout:  defaultInstanceTimeout,
+			shutdown: func() {},
+		},
+	}
+
+	// apply options
+	for _, opt := range options {
+		opt(&res.builtinInstance)
+	}
+
+	// init timer
+	res.timeoutTicker = time.NewTicker(res.timeout)
+
+	// setup internally-cancellable context
+	prevCancel := res.shutdown
+	cancelableCtx, cancelCtx := context.WithCancel(res.ctx)
+	res.ctx = cancelableCtx
+	res.shutdown = func() {
+		cancelCtx()
+		prevCancel()
+	}
+
+	return res, nil
+}

--- a/pkg/sdk/plugins/source/instance_test.go
+++ b/pkg/sdk/plugins/source/instance_test.go
@@ -70,7 +70,7 @@ func benchPullInstance(b *testing.B, onEvt func() []byte) {
 		_, err := e.Writer().Write(onEvt())
 		return err
 	}
-	inst, err := OpenPullInstance(pull, WithInstanceTimeout(benchEvtTimeout))
+	inst, err := NewPullInstance(pull, WithInstanceTimeout(benchEvtTimeout))
 	if err != nil {
 		b.Fatal(err.Error())
 	}
@@ -89,7 +89,7 @@ func benchPushInstance(b *testing.B, onEvt func() []byte) {
 			}
 		}
 	}()
-	inst, err := OpenPushInstance(evtChan, WithInstanceTimeout(benchEvtTimeout))
+	inst, err := NewPushInstance(evtChan, WithInstanceTimeout(benchEvtTimeout))
 	if err != nil {
 		b.Fatal(err.Error())
 	}
@@ -167,7 +167,7 @@ func TestPullInstance(t *testing.T) {
 	close := func() { closed = true }
 
 	// open instance
-	inst, err := OpenPullInstance(
+	inst, err := NewPullInstance(
 		pull,
 		WithInstanceTimeout(timeout),
 		WithInstanceClose(close),
@@ -222,7 +222,7 @@ func TestPullInstanceCtxCanceling(t *testing.T) {
 	pull := func(c context.Context, e sdk.EventWriter) error {
 		return sdk.ErrTimeout
 	}
-	inst, err := OpenPullInstance(pull, WithInstanceContext(ctx))
+	inst, err := NewPullInstance(pull, WithInstanceContext(ctx))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -275,7 +275,7 @@ func TestPushInstance(t *testing.T) {
 	close := func() { closed = true }
 
 	// open instance
-	inst, err := OpenPushInstance(
+	inst, err := NewPushInstance(
 		evtChan,
 		WithInstanceTimeout(timeout),
 		WithInstanceClose(close),
@@ -328,7 +328,7 @@ func TestPushInstanceChanClosing(t *testing.T) {
 	}
 
 	evtChan := make(chan PushEvent)
-	inst, err := OpenPushInstance(evtChan)
+	inst, err := NewPushInstance(evtChan)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -363,7 +363,7 @@ func TestPushInstanceCtxCanceling(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	evtChan := make(chan PushEvent)
 	defer close(evtChan)
-	inst, err := OpenPushInstance(evtChan, WithInstanceContext(ctx))
+	inst, err := NewPushInstance(evtChan, WithInstanceContext(ctx))
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/sdk/plugins/source/instance_test.go
+++ b/pkg/sdk/plugins/source/instance_test.go
@@ -66,7 +66,7 @@ func benchNextBatch(b *testing.B, inst Instance, batchSize, evtCount int) {
 }
 
 func benchPullInstance(b *testing.B, onEvt func() []byte) {
-	pull := func(c context.Context, s sdk.PluginState, e sdk.EventWriter) error {
+	pull := func(c context.Context, e sdk.EventWriter) error {
 		_, err := e.Writer().Write(onEvt())
 		return err
 	}
@@ -150,7 +150,7 @@ func TestPullInstance(t *testing.T) {
 
 	// setup evt generation callback
 	nEvt := 0
-	pull := func(c context.Context, s sdk.PluginState, e sdk.EventWriter) error {
+	pull := func(c context.Context, e sdk.EventWriter) error {
 		if nEvt == 0 {
 			time.Sleep(timeout * 10)
 		}
@@ -219,7 +219,7 @@ func TestPullInstanceCtxCanceling(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	pull := func(c context.Context, s sdk.PluginState, e sdk.EventWriter) error {
+	pull := func(c context.Context, e sdk.EventWriter) error {
 		return sdk.ErrTimeout
 	}
 	inst, err := OpenPullInstance(pull, WithInstanceContext(ctx))

--- a/pkg/sdk/plugins/source/instance_test.go
+++ b/pkg/sdk/plugins/source/instance_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+	sdkint "github.com/falcosecurity/plugin-sdk-go/pkg/sdk/internal/sdk"
 )
 
 const (
@@ -36,9 +37,9 @@ const (
 )
 
 func benchNextBatch(b *testing.B, inst Instance, batchSize uint32, evtCount int) {
-	batch := &sdk.InMemoryEventWriters{}
+	batch := &sdkint.InMemoryEventWriters{}
 	for i := uint32(0); i < batchSize; i++ {
-		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+		batch.Writers = append(batch.Writers, &sdkint.InMemoryEventWriter{})
 	}
 	b.ResetTimer()
 	tot := 0
@@ -143,9 +144,9 @@ func TestPullInstance(t *testing.T) {
 	timeout := time.Millisecond * 10
 
 	// create batch
-	batch := &sdk.InMemoryEventWriters{}
+	batch := &sdkint.InMemoryEventWriters{}
 	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
-		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+		batch.Writers = append(batch.Writers, &sdkint.InMemoryEventWriter{})
 	}
 
 	// setup evt generation callback
@@ -213,9 +214,9 @@ func TestPullInstance(t *testing.T) {
 
 func TestPullInstanceCtxCanceling(t *testing.T) {
 	// create batch
-	batch := &sdk.InMemoryEventWriters{}
+	batch := &sdkint.InMemoryEventWriters{}
 	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
-		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+		batch.Writers = append(batch.Writers, &sdkint.InMemoryEventWriter{})
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -251,9 +252,9 @@ func TestPushInstance(t *testing.T) {
 	timeout := time.Millisecond * 100
 
 	// create batch
-	batch := &sdk.InMemoryEventWriters{}
+	batch := &sdkint.InMemoryEventWriters{}
 	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
-		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+		batch.Writers = append(batch.Writers, &sdkint.InMemoryEventWriter{})
 	}
 
 	// setup evt generation worker
@@ -322,9 +323,9 @@ func TestPushInstance(t *testing.T) {
 
 func TestPushInstanceChanClosing(t *testing.T) {
 	// create batch
-	batch := &sdk.InMemoryEventWriters{}
+	batch := &sdkint.InMemoryEventWriters{}
 	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
-		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+		batch.Writers = append(batch.Writers, &sdkint.InMemoryEventWriter{})
 	}
 
 	evtChan := make(chan PushEvent)
@@ -355,9 +356,9 @@ func TestPushInstanceChanClosing(t *testing.T) {
 
 func TestPushInstanceCtxCanceling(t *testing.T) {
 	// create batch
-	batch := &sdk.InMemoryEventWriters{}
+	batch := &sdkint.InMemoryEventWriters{}
 	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
-		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+		batch.Writers = append(batch.Writers, &sdkint.InMemoryEventWriter{})
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/sdk/plugins/source/instance_test.go
+++ b/pkg/sdk/plugins/source/instance_test.go
@@ -35,9 +35,9 @@ const (
 	benchEvtTimeout       = 30 * time.Millisecond
 )
 
-func benchNextBatch(b *testing.B, inst Instance, batchSize, evtCount int) {
+func benchNextBatch(b *testing.B, inst Instance, batchSize uint32, evtCount int) {
 	batch := &sdk.InMemoryEventWriters{}
-	for i := 0; i < batchSize; i++ {
+	for i := uint32(0); i < batchSize; i++ {
 		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
 	}
 	b.ResetTimer()
@@ -144,7 +144,7 @@ func TestPullInstance(t *testing.T) {
 
 	// create batch
 	batch := &sdk.InMemoryEventWriters{}
-	for i := 0; i < sdk.DefaultBatchSize; i++ {
+	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
 		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
 	}
 
@@ -214,7 +214,7 @@ func TestPullInstance(t *testing.T) {
 func TestPullInstanceCtxCanceling(t *testing.T) {
 	// create batch
 	batch := &sdk.InMemoryEventWriters{}
-	for i := 0; i < sdk.DefaultBatchSize; i++ {
+	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
 		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
 	}
 
@@ -252,7 +252,7 @@ func TestPushInstance(t *testing.T) {
 
 	// create batch
 	batch := &sdk.InMemoryEventWriters{}
-	for i := 0; i < sdk.DefaultBatchSize; i++ {
+	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
 		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
 	}
 
@@ -323,7 +323,7 @@ func TestPushInstance(t *testing.T) {
 func TestPushInstanceChanClosing(t *testing.T) {
 	// create batch
 	batch := &sdk.InMemoryEventWriters{}
-	for i := 0; i < sdk.DefaultBatchSize; i++ {
+	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
 		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
 	}
 
@@ -356,7 +356,7 @@ func TestPushInstanceChanClosing(t *testing.T) {
 func TestPushInstanceCtxCanceling(t *testing.T) {
 	// create batch
 	batch := &sdk.InMemoryEventWriters{}
-	for i := 0; i < sdk.DefaultBatchSize; i++ {
+	for i := uint32(0); i < sdk.DefaultBatchSize; i++ {
 		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
 	}
 

--- a/pkg/sdk/plugins/source/instance_test.go
+++ b/pkg/sdk/plugins/source/instance_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package source
 
 import (
@@ -121,4 +137,253 @@ func BenchmarkPushRandom(b *testing.B) {
 	benchPushInstance(b, func() []byte {
 		return createEventData((rand.Uint32() % (benchMaxEvtDataSize - benchMinEvtDataSize)) + benchMinEvtDataSize)
 	})
+}
+
+func TestPullInstance(t *testing.T) {
+	timeout := time.Millisecond * 10
+
+	// create batch
+	batch := &sdk.InMemoryEventWriters{}
+	for i := 0; i < sdk.DefaultBatchSize; i++ {
+		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+	}
+
+	// setup evt generation callback
+	nEvt := 0
+	pull := func(c context.Context, s sdk.PluginState, e sdk.EventWriter) error {
+		if nEvt == 0 {
+			time.Sleep(timeout * 10)
+		}
+		if nEvt == 3 {
+			return sdk.ErrEOF
+		}
+		nEvt++
+		e.Writer().Write(createEventData(100))
+		return nil
+	}
+
+	// setup closing callback
+	closed := false
+	close := func() { closed = true }
+
+	// open instance
+	inst, err := OpenPullInstance(
+		pull,
+		WithInstanceTimeout(timeout),
+		WithInstanceClose(close),
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// fist call to nextbatch should trigger the timeout and return 1 evt
+	n, err := inst.NextBatch(nil, batch)
+	if err != sdk.ErrTimeout {
+		t.Fatalf("expected sdk.ErrTimeout, but found error: %s ", err)
+	} else if n != 1 {
+		t.Fatalf("expected %d, but found %d", 1, n)
+	}
+
+	// second call to nextbatch should trigger the EOF and return 2 evts
+	n, err = inst.NextBatch(nil, batch)
+	if err != sdk.ErrEOF {
+		t.Fatalf("expected sdk.ErrEOF, but found error: %s ", err)
+	} else if n != 2 {
+		t.Fatalf("expected %d, but found %d", 2, n)
+	}
+
+	// close instance
+	closer, ok := inst.(sdk.Closer)
+	if !ok {
+		t.Fatalf("instance does not implement sdk.Closer")
+	}
+	closer.Close()
+	if !closed {
+		t.Fatalf("expected close callback to be invoked")
+	}
+
+	// every other call should return EOF
+	n, err = inst.NextBatch(nil, batch)
+	if err != sdk.ErrEOF {
+		t.Fatalf("expected sdk.ErrEOF, but found error: %s ", err)
+	} else if n != 0 {
+		t.Fatalf("expected %d, but found %d", 0, n)
+	}
+}
+
+func TestPullInstanceCtxCanceling(t *testing.T) {
+	// create batch
+	batch := &sdk.InMemoryEventWriters{}
+	for i := 0; i < sdk.DefaultBatchSize; i++ {
+		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pull := func(c context.Context, s sdk.PluginState, e sdk.EventWriter) error {
+		return sdk.ErrTimeout
+	}
+	inst, err := OpenPullInstance(pull, WithInstanceContext(ctx))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// fist call to nextbatch should trigger the timeout and return no evts
+	n, err := inst.NextBatch(nil, batch)
+	if err != sdk.ErrTimeout {
+		t.Fatalf("expected sdk.ErrTimeout, but found error: %s ", err)
+	} else if n != 0 {
+		t.Fatalf("expected %d, but found %d", 0, n)
+	}
+
+	// cancel context
+	cancel()
+
+	// next call to nextbatch should trigger EOF
+	n, err = inst.NextBatch(nil, batch)
+	if err != sdk.ErrEOF {
+		t.Fatalf("expected sdk.ErrEOF, but found error: %s ", err)
+	} else if n != 0 {
+		t.Fatalf("expected %d, but found %d", 0, n)
+	}
+}
+
+func TestPushInstance(t *testing.T) {
+	timeout := time.Millisecond * 100
+
+	// create batch
+	batch := &sdk.InMemoryEventWriters{}
+	for i := 0; i < sdk.DefaultBatchSize; i++ {
+		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+	}
+
+	// setup evt generation worker
+	evtChan := make(chan PushEvent)
+	waitChan := make(chan bool)
+	defer close(evtChan)
+	defer close(waitChan)
+	go func() {
+		data := createEventData(100)
+		evtChan <- PushEvent{Data: data}
+		<-waitChan // trigger timeout at first event
+		evtChan <- PushEvent{Data: data}
+		evtChan <- PushEvent{Data: data}
+		evtChan <- PushEvent{Err: sdk.ErrEOF}
+	}()
+
+	// setup closing callback
+	closed := false
+	close := func() { closed = true }
+
+	// open instance
+	inst, err := OpenPushInstance(
+		evtChan,
+		WithInstanceTimeout(timeout),
+		WithInstanceClose(close),
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// fist call to nextbatch should trigger the timeout and return evts
+	n, err := inst.NextBatch(nil, batch)
+	if err != sdk.ErrTimeout {
+		t.Fatalf("expected sdk.ErrTimeout, but found error: %s ", err)
+	} else if n != 1 {
+		t.Fatalf("expected %d, but found %d", 1, n)
+	}
+	waitChan <- true
+
+	// second call to nextbatch should trigger the EOF and return 2 evts
+	n, err = inst.NextBatch(nil, batch)
+	if err != sdk.ErrEOF {
+		t.Fatalf("expected sdk.ErrEOF, but found error: %s ", err)
+	} else if n != 2 {
+		t.Fatalf("expected %d, but found %d", 2, n)
+	}
+
+	// close instance
+	closer, ok := inst.(sdk.Closer)
+	if !ok {
+		t.Fatalf("instance does not implement sdk.Closer")
+	}
+	closer.Close()
+	if !closed {
+		t.Fatalf("expected close callback to be invoked")
+	}
+
+	// every other call should return EOF
+	n, err = inst.NextBatch(nil, batch)
+	if err != sdk.ErrEOF {
+		t.Fatalf("expected sdk.ErrEOF, but found error: %s ", err)
+	} else if n != 0 {
+		t.Fatalf("expected %d, but found %d", 0, n)
+	}
+}
+
+func TestPushInstanceChanClosing(t *testing.T) {
+	// create batch
+	batch := &sdk.InMemoryEventWriters{}
+	for i := 0; i < sdk.DefaultBatchSize; i++ {
+		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+	}
+
+	evtChan := make(chan PushEvent)
+	inst, err := OpenPushInstance(evtChan)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// fist call to nextbatch should trigger the timeout and return no evts
+	n, err := inst.NextBatch(nil, batch)
+	if err != sdk.ErrTimeout {
+		t.Fatalf("expected sdk.ErrTimeout, but found error: %s ", err)
+	} else if n != 0 {
+		t.Fatalf("expected %d, but found %d", 0, n)
+	}
+
+	// close channel
+	close(evtChan)
+
+	// next call to nextbatch should trigger EOF
+	n, err = inst.NextBatch(nil, batch)
+	if err != sdk.ErrEOF {
+		t.Fatalf("expected sdk.ErrEOF, but found error: %s ", err)
+	} else if n != 0 {
+		t.Fatalf("expected %d, but found %d", 0, n)
+	}
+}
+
+func TestPushInstanceCtxCanceling(t *testing.T) {
+	// create batch
+	batch := &sdk.InMemoryEventWriters{}
+	for i := 0; i < sdk.DefaultBatchSize; i++ {
+		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	evtChan := make(chan PushEvent)
+	defer close(evtChan)
+	inst, err := OpenPushInstance(evtChan, WithInstanceContext(ctx))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// fist call to nextbatch should trigger the timeout and return no evts
+	n, err := inst.NextBatch(nil, batch)
+	if err != sdk.ErrTimeout {
+		t.Fatalf("expected sdk.ErrTimeout, but found error: %s ", err)
+	} else if n != 0 {
+		t.Fatalf("expected %d, but found %d", 0, n)
+	}
+
+	// cancel context
+	cancel()
+
+	// next call to nextbatch should trigger EOF
+	n, err = inst.NextBatch(nil, batch)
+	if err != sdk.ErrEOF {
+		t.Fatalf("expected sdk.ErrEOF, but found error: %s ", err)
+	} else if n != 0 {
+		t.Fatalf("expected %d, but found %d", 0, n)
+	}
 }

--- a/pkg/sdk/plugins/source/instance_test.go
+++ b/pkg/sdk/plugins/source/instance_test.go
@@ -1,0 +1,124 @@
+package source
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+const (
+	benchFixedEvtDataSize = 1024
+	benchMinEvtDataSize   = 1024
+	benchMaxEvtDataSize   = 1 * 1024 * 1204
+	benchEvtCount         = 1024
+	benchEvtBatchSize     = sdk.DefaultBatchSize
+	benchEvtTimeout       = 30 * time.Millisecond
+)
+
+func benchNextBatch(b *testing.B, inst Instance, batchSize, evtCount int) {
+	batch := &sdk.InMemoryEventWriters{}
+	for i := 0; i < batchSize; i++ {
+		batch.Writers = append(batch.Writers, &sdk.InMemoryEventWriter{})
+	}
+	b.ResetTimer()
+	tot := 0
+	n := 0
+	var err error
+	for i := 0; i < b.N; i++ {
+		tot = 0
+		for tot < evtCount {
+			n, err = inst.NextBatch(nil, batch)
+			if err != nil {
+				if err == sdk.ErrEOF {
+					break
+				}
+				if err != sdk.ErrTimeout {
+					b.Fatal(err.Error())
+				}
+			}
+			tot += n
+		}
+	}
+	b.StopTimer()
+	if closer, ok := inst.(sdk.Closer); ok {
+		closer.Close()
+	}
+}
+
+func benchPullInstance(b *testing.B, onEvt func() []byte) {
+	pull := func(c context.Context, s sdk.PluginState, e sdk.EventWriter) error {
+		_, err := e.Writer().Write(onEvt())
+		return err
+	}
+	inst, err := OpenPullInstance(pull, WithInstanceTimeout(benchEvtTimeout))
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+	benchNextBatch(b, inst, benchEvtBatchSize, benchEvtCount)
+}
+
+func benchPushInstance(b *testing.B, onEvt func() []byte) {
+	evtChan := make(chan PushEvent)
+	stopChan := make(chan bool)
+	go func() {
+		for {
+			select {
+			case evtChan <- PushEvent{Data: onEvt()}:
+			case <-stopChan:
+				return
+			}
+		}
+	}()
+	inst, err := OpenPushInstance(evtChan, WithInstanceTimeout(benchEvtTimeout))
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+	benchNextBatch(b, inst, benchEvtBatchSize, benchEvtCount)
+	stopChan <- true
+	close(stopChan)
+	close(evtChan)
+}
+
+// simulate event generation
+func createEventData(size uint32) []byte {
+	buf := bytes.Buffer{}
+	for size > 0 {
+		buf.WriteByte(0)
+		size--
+	}
+	return buf.Bytes()
+}
+
+func BenchmarkPullEmpty(b *testing.B) {
+	data := []byte{}
+	benchPullInstance(b, func() []byte { return data })
+}
+
+func BenchmarkPushEmpty(b *testing.B) {
+	data := []byte{}
+	benchPushInstance(b, func() []byte { return data })
+}
+
+func BenchmarkPullFixed(b *testing.B) {
+	benchPullInstance(b, func() []byte { return createEventData(benchFixedEvtDataSize) })
+}
+
+func BenchmarkPushFixed(b *testing.B) {
+	benchPushInstance(b, func() []byte { return createEventData(benchFixedEvtDataSize) })
+}
+
+func BenchmarkPullRandom(b *testing.B) {
+	benchPullInstance(b, func() []byte {
+		return createEventData((rand.Uint32() % (benchMaxEvtDataSize - benchMinEvtDataSize)) + benchMinEvtDataSize)
+	})
+}
+
+func BenchmarkPushRandom(b *testing.B) {
+	benchPushInstance(b, func() []byte {
+		return createEventData((rand.Uint32() % (benchMaxEvtDataSize - benchMinEvtDataSize)) + benchMinEvtDataSize)
+	})
+}

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -45,7 +45,7 @@ const DefaultEvtSize uint32 = 256 * 1024
 
 // DefaultBatchSize is the default number of events in the EventWriters
 // interface used by the SDK.
-const DefaultBatchSize = 128
+const DefaultBatchSize uint32 = 128
 
 // The full set of values that can be returned in the ftype
 // member of ss_plugin_extract_field structs.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

/area tests

**What this PR does / why we need it**:

This PR introduces two builtin implementations of the `source.Instance` interface of the `sdk/plugins/source` package. This interface is responsible of representing opened event sources and of producing event data through the `NextBatch()` method.

There are two built-in implementations provided, each implemented for its use case:
- _"Pull model"_: for use cases in which the event source can be implemented sequentially and the time required to generate a sequence of event is deterministic. This is implemented with a functional design, where the passed-in callback is expected to be non-suspensive and to return quickly.
- _"Push model"_: for use cases in with the event source can be suspensive and there is no time guarantee reguarding when an event gets produced. For instance, this applies for all event sources that generate events from webhook events. Given the event-driven nature of this use case, this is implemented by passing event data in the form of byte slices through a channel.

On top of this, in-memory implementations have been added for core SDK interfaces such as `sdk.EventWriter` and `sdk.EventReader`. This is now used to implement benchmarks and unit tests for the two _push_ and _pull_ implementations. This was a long due necessity in the SDK, and these new `sdk.InMemory*` types can be used for a variety of use cases (tests being the most obvious ones).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

After starting developing the first plugins, I came to the conclusion that implementing the `NextBatch()` is not trivial in the general case. There are many things to be aware of:
- Return as fast as possible and should try to fill-up the event batch as much as possible
- Listen for a timeout and return the batch in its current state once the timeout is expired
- Conceive the case in which `Close()` is called before `NextBatch()` has returned. This can happen if the plugin framework receives signals such as `CTRL+C` from the user.
- Keep memory allocations to the minimum
- Keep returning EOF after returning it the first time

As such, I though that creating an officially-maintained version of it for few use cases would be beneficial for the community. As a matter of fact, most of the plugins under the `falcosecurity/plugins` repo could be refactored to use these newly-introduced prebuilts.

Obviously, the SDK leaves plugin developers the choice of implementing their own `source.Instance` type with custom `NextBatch()` implementations for advanced or specific use cases.

**Does this PR introduce a user-facing change?**:

```release-note
new(sdk/plugins): add builtin event stream instance implementations for push and pull models
```
