### PR TITLE
fix: subsequent init support

### DIFF
--- a/examples/extractor/extractor.go
+++ b/examples/extractor/extractor.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,7 +45,11 @@ type MyPlugin struct {
 // interface, so compilation will fail if the mandatory methods are not
 // implemented.
 func init() {
-	extractor.Register(&MyPlugin{})
+	plugins.SetFactory(func() plugins.Plugin {
+		p := &MyPlugin{}
+		extractor.Register(p)
+		return p
+	})
 }
 
 // Info returns a pointer to a plugin.Info struct, containing all the

--- a/examples/full/full.go
+++ b/examples/full/full.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -79,9 +79,12 @@ type MyInstance struct {
 // This requires our plugin to implement the source.Plugin interface, so
 // compilation will fail if the mandatory methods are not implemented.
 func init() {
-	p := &MyPlugin{}
-	extractor.Register(p)
-	source.Register(p)
+	plugins.SetFactory(func() plugins.Plugin {
+		p := &MyPlugin{}
+		source.Register(p)
+		extractor.Register(p)
+		return p
+	})
 }
 
 // Info returns a pointer to a plugin.Info struct, containing all the

--- a/examples/source/source.go
+++ b/examples/source/source.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -64,7 +64,11 @@ type MyInstance struct {
 // interface, so compilation will fail if the mandatory methods are not
 // implemented.
 func init() {
-	source.Register(&MyPlugin{})
+	plugins.SetFactory(func() plugins.Plugin {
+		p := &MyPlugin{}
+		source.Register(p)
+		return p
+	})
 }
 
 // Info returns a pointer to a plugin.Info struct, containing all the

--- a/pkg/sdk/plugins/extractor/extractor.go
+++ b/pkg/sdk/plugins/extractor/extractor.go
@@ -38,6 +38,13 @@ type Plugin interface {
 	Fields() []sdk.FieldEntry
 }
 
+func enableAsync(handle cgo.Handle) {
+	extract.StartAsync()
+	hooks.SetOnBeforeDestroy(func(handle cgo.Handle) {
+		extract.StopAsync()
+	})
+}
+
 // Register registers the field extraction capability in the framework for the given Plugin.
 //
 // This function should be called from the provided plugins.FactoryFunc implementation.
@@ -47,10 +54,5 @@ func Register(p Plugin) {
 	fields.SetFields(p.Fields())
 
 	// setup hooks for automatically start/stop async extraction
-	hooks.SetOnAfterInit(func(handle cgo.Handle) {
-		extract.StartAsync()
-		hooks.SetOnBeforeDestroy(func(handle cgo.Handle) {
-			extract.StopAsync()
-		})
-	})
+	hooks.SetOnAfterInit(enableAsync)
 }

--- a/pkg/sdk/plugins/extractor/extractor.go
+++ b/pkg/sdk/plugins/extractor/extractor.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,13 +25,8 @@ import (
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/extract"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/fields"
-	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/info"
-	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/initialize"
-	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/initschema"
 	_ "github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/lasterr"
 )
-
-var registered = false
 
 // Plugin is an interface representing a plugin with field extraction capability.
 type Plugin interface {
@@ -43,33 +38,13 @@ type Plugin interface {
 	Fields() []sdk.FieldEntry
 }
 
-// Register registers a Plugin in the framework. This function
-// needs to be called in a Go init() function. Calling this function more than
-// once will cause a panic.
+// Register registers the field extraction capability in the framework for the given Plugin.
 //
+// This function should be called from the provided plugins.FactoryFunc implementation.
+// See the parent package for more detail. This function is idempotent.
 func Register(p Plugin) {
-	if registered {
-		panic("plugin-sdk-go/sdk/plugins/extractor: register can be called only once")
-	}
-
-	i := p.Info()
-	info.SetId(i.ID)
-	info.SetName(i.Name)
-	info.SetDescription(i.Description)
-	info.SetContact(i.Contact)
-	info.SetVersion(i.Version)
-	info.SetRequiredAPIVersion(i.RequiredAPIVersion)
-	info.SetExtractEventSources(i.ExtractEventSources)
-	if initSchema, ok := p.(sdk.InitSchema); ok {
-		initschema.SetInitSchema(initSchema.InitSchema())
-	}
 
 	fields.SetFields(p.Fields())
-
-	initialize.SetOnInit(func(c string) (sdk.PluginState, error) {
-		err := p.Init(c)
-		return p, err
-	})
 
 	// setup hooks for automatically start/stop async extraction
 	hooks.SetOnAfterInit(func(handle cgo.Handle) {
@@ -78,6 +53,4 @@ func Register(p Plugin) {
 			extract.StopAsync()
 		})
 	})
-
-	registered = true
 }

--- a/pkg/sdk/plugins/plugins.go
+++ b/pkg/sdk/plugins/plugins.go
@@ -140,7 +140,7 @@ type BasePlugin struct {
 // FactoryFunc creates a new Plugin
 type FactoryFunc func() Plugin
 
-// SetFactory sets the FactoryFunc to be called when creating a new Plugin.
+// SetFactory sets the FactoryFunc to be used by the SDK when creating a new Plugin
 //
 // SetFactory should be called in the Go init() function of the plugin main package.
 // It hooks the plugin framework initialization stage to create a new Plugin and

--- a/pkg/sdk/plugins/plugins.go
+++ b/pkg/sdk/plugins/plugins.go
@@ -168,27 +168,29 @@ type FactoryFunc func() Plugin
 //	}
 //
 func SetFactory(f FactoryFunc) {
-	initialize.SetOnInit(func(c string) (sdk.PluginState, error) {
 
+	// Create a new plugin instance to get static plugin info
+	p := f()
+
+	// Set up plugin info
+	i := p.Info()
+	info.SetId(i.ID)
+	info.SetName(i.Name)
+	info.SetDescription(i.Description)
+	info.SetEventSource(i.EventSource)
+	info.SetExtractEventSources(i.ExtractEventSources)
+	info.SetContact(i.Contact)
+	info.SetVersion(i.Version)
+	info.SetRequiredAPIVersion(i.RequiredAPIVersion)
+
+	// Set up plugin init schema, if any
+	if initSchema, ok := p.(sdk.InitSchema); ok {
+		initschema.SetInitSchema(initSchema.InitSchema())
+	}
+
+	initialize.SetOnInit(func(c string) (sdk.PluginState, error) {
 		// Create a new plugin instance
 		p := f()
-
-		// Set up plugin info
-		i := p.Info()
-		info.SetId(i.ID)
-		info.SetName(i.Name)
-		info.SetDescription(i.Description)
-		info.SetEventSource(i.EventSource)
-		info.SetExtractEventSources(i.ExtractEventSources)
-		info.SetContact(i.Contact)
-		info.SetVersion(i.Version)
-		info.SetRequiredAPIVersion(i.RequiredAPIVersion)
-
-		// Set up plugin init schema, if any
-		if initSchema, ok := p.(sdk.InitSchema); ok {
-			initschema.SetInitSchema(initSchema.InitSchema())
-		}
-
 		err := p.Init(c)
 		return p, err
 	})

--- a/pkg/sdk/plugins/plugins.go
+++ b/pkg/sdk/plugins/plugins.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ package plugins
 import (
 	"github.com/falcosecurity/plugin-sdk-go/pkg/ptr"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/info"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/initialize"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/symbols/initschema"
 )
 
 // Info is a struct containing the general information about a plugin.
@@ -132,4 +135,61 @@ type BasePlugin struct {
 	BaseStringer
 	BaseExtractRequests
 	BaseOpenParams
+}
+
+// FactoryFunc creates a new Plugin
+type FactoryFunc func() Plugin
+
+// SetFactory sets the FactoryFunc to be called when creating a new Plugin.
+//
+// SetFactory should be called in the Go init() function of the plugin main package.
+// It hooks the plugin framework initialization stage to create a new Plugin and
+// to set up common facilities provided by this SDK. The given FactoryFunc must create
+// a Plugin and can optionally enable plugin capabilities by using the Register functions
+// provided by sub-packages. This function is idempotent.
+//
+// Usage example:
+//
+//	package main
+//
+//	import (
+//		"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"
+//		"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins/extractor"
+//		"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins/source"
+//	)
+//
+//	func init() {
+//		plugins.SetFactory(func() plugins.Plugin {
+//			p := &MyPlugin{} // create a new Plugin
+//			source.Register(p) // enable event sourcing capability
+//			extractor.Register(p) // enable field extraction capability
+//			return p
+//		})
+//	}
+//
+func SetFactory(f FactoryFunc) {
+	initialize.SetOnInit(func(c string) (sdk.PluginState, error) {
+
+		// Create a new plugin instance
+		p := f()
+
+		// Set up plugin info
+		i := p.Info()
+		info.SetId(i.ID)
+		info.SetName(i.Name)
+		info.SetDescription(i.Description)
+		info.SetEventSource(i.EventSource)
+		info.SetExtractEventSources(i.ExtractEventSources)
+		info.SetContact(i.Contact)
+		info.SetVersion(i.Version)
+		info.SetRequiredAPIVersion(i.RequiredAPIVersion)
+
+		// Set up plugin init schema, if any
+		if initSchema, ok := p.(sdk.InitSchema); ok {
+			initschema.SetInitSchema(initSchema.InitSchema())
+		}
+
+		err := p.Init(c)
+		return p, err
+	})
 }

--- a/pkg/sdk/plugins/source/source_test.go
+++ b/pkg/sdk/plugins/source/source_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@ limitations under the License.
 package source
 
 import (
-	"testing"
-
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
 	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"
 )
@@ -57,21 +55,4 @@ func (m *testPlugin) String(evt sdk.EventReader) (string, error) {
 
 func (m *testInstance) NextBatch(pState sdk.PluginState, evts sdk.EventWriters) (int, error) {
 	return 0, nil
-}
-
-func assertPanic(t *testing.T, fun func()) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("expected panic")
-		}
-	}()
-	fun()
-}
-
-func TestRegister(t *testing.T) {
-	registerFunc := func() {
-		Register(&testPlugin{})
-	}
-	registerFunc()
-	assertPanic(t, registerFunc)
 }


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR changes the way we initialize the plugin object in the SDK in order to support multiple re-initializations.
See `SetFuctory()` comment for more detail.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
new(pkg/sdk/plugins): introduce FactoryFunc and SetFactory()
```
