### PR TITLE
new: introduce plugin loader code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,15 @@ clean: clean-pluginlib $(examples_clean)
 pluginlib:
 	@$(CURL) -Lso pkg/sdk/plugin_types.h $(PLUGINLIB_URL)/plugin_types.h
 	@$(CURL) -Lso pkg/sdk/plugin_api.h $(PLUGINLIB_URL)/plugin_api.h
+	@$(CURL) -Lso pkg/loader/plugin_loader.h $(PLUGINLIB_URL)/plugin_loader.h
+	@$(CURL) -Lso pkg/loader/plugin_loader.c $(PLUGINLIB_URL)/plugin_loader.c
 
 clean-pluginlib:
 	@rm -f \
 		pkg/sdk/plugin_types.h \
 		pkg/sdk/plugin_api.h \
+		pkg/loader/plugin_loader.h \
+		pkg/loader/plugin_loader.c
 
 .PHONY: test
 test:

--- a/benchmarks/async/go.sum
+++ b/benchmarks/async/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/examples/custom/go.sum
+++ b/examples/custom/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/examples/extractor/go.sum
+++ b/examples/extractor/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/examples/full/go.sum
+++ b/examples/full/go.sum
@@ -7,5 +7,10 @@ github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709 h1:Ko2LQMrRU+Oy/+EDBwX7eZ2jp3C47eDBB8EIhKTun+I=
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/examples/source/go.sum
+++ b/examples/source/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/falcosecurity/plugin-sdk-go
 
 go 1.15
+
+require (
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -1,0 +1,341 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+// note: cgo does not support macros and function pointers, so we have to
+// create wrappers around those to access them from Go code
+
+/*
+#cgo linux LDFLAGS: -ldl
+#cgo CFLAGS: -I ../sdk
+
+#include "plugin_loader.h"
+#include <stdlib.h>
+
+uint32_t __plugin_max_errlen = PLUGIN_MAX_ERRLEN;
+
+static uint32_t __get_info_u32(uint32_t (*f)())
+{
+	if (!f) return 0;
+    return f();
+}
+
+static const char* __get_info_str(const char *(*f)())
+{
+	if (!f) return "";
+    return f();
+}
+
+static const char *__get_init_schema(plugin_api* p, ss_plugin_schema_type *s)
+{
+    return p->get_init_schema(s);
+}
+
+static ss_plugin_t* __init(plugin_api* p, const char *cfg, ss_plugin_rc *rc)
+{
+    return p->init(cfg, rc);
+}
+
+static void __destroy(plugin_api* p, ss_plugin_t* s)
+{
+	p->destroy(s);
+}
+
+static const char* __get_last_err(plugin_api* p, ss_plugin_t* s)
+{
+    return p->get_last_error(s);
+}
+
+static ss_instance_t* __open(plugin_api* p, ss_plugin_t* s, const char* o, ss_plugin_rc* r)
+{
+    return p->open(s, o, r);
+}
+
+static void __close(plugin_api* p, ss_plugin_t* s, ss_instance_t* h)
+{
+    p->close(s, h);
+}
+
+static const char* __list_open_params(plugin_api* p, ss_plugin_t* s, ss_plugin_rc* rc)
+{
+    return p->list_open_params(s, rc);
+}
+
+static const char* __get_progress(plugin_api* p, ss_plugin_t* s, ss_instance_t* h, uint32_t* r)
+{
+    return p->get_progress(s, h, r);
+}
+
+static const char* __event_to_string(plugin_api* p, ss_plugin_t *s, const ss_plugin_event *e)
+{
+    return p->event_to_string(s, e);
+}
+
+static ss_plugin_rc __next_batch(plugin_api* p, ss_plugin_t* s, ss_instance_t* h, uint32_t *n, ss_plugin_event **e)
+{
+    return p->next_batch(s, h, n, e);
+}
+
+static ss_plugin_rc __extract_fields(plugin_api* p, ss_plugin_t *s, const ss_plugin_event *e, uint32_t n, ss_plugin_extract_field *f)
+{
+    return p->extract_fields(s, e, n, f);
+}
+
+*/
+import "C"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk/plugins"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+var (
+	errNotInitialized = errors.New("plugin is not initialized")
+	errNoSourcingCap  = errors.New("plugin does not support event sourcing capability")
+)
+
+type Plugin struct {
+	m          sync.Mutex
+	handle     *C.plugin_handle_t
+	state      *C.ss_plugin_t
+	caps       C.plugin_caps_t
+	info       plugins.Info
+	initSchema *sdk.SchemaInfo
+	fields     []sdk.FieldEntry
+	validated  bool
+	validErr   error
+}
+
+func LoadAndValidate(path string) (*Plugin, error) {
+	p, err := Load(path)
+	if err != nil {
+		return nil, err
+	}
+	err = p.Validate()
+	if err != nil {
+		p.Unload()
+		return nil, err
+	}
+	return p, nil
+}
+
+func Load(path string) (*Plugin, error) {
+	// load library
+	errBuf := (*C.char)(C.malloc(C.uint64_t(C.__plugin_max_errlen) * C.sizeof_char))
+	defer C.free(unsafe.Pointer(errBuf))
+	p := &Plugin{}
+	p.handle = C.plugin_load(C.CString(path), errBuf)
+	if p.handle == nil {
+		return nil, errors.New(C.GoString(errBuf))
+	}
+
+	// get supported capabilities
+	p.caps = C.plugin_get_capabilities(p.handle)
+
+	// read static info (if available)
+	p.info = plugins.Info{
+		Version:             C.GoString(C.__get_info_str(p.handle.api.get_version)),
+		RequiredAPIVersion:  C.GoString(C.__get_info_str(p.handle.api.get_required_api_version)),
+		Name:                C.GoString(C.__get_info_str(p.handle.api.get_name)),
+		Description:         C.GoString(C.__get_info_str(p.handle.api.get_description)),
+		EventSource:         C.GoString(C.__get_info_str(p.handle.api.anon0.get_event_source)),
+		Contact:             C.GoString(C.__get_info_str(p.handle.api.get_contact)),
+		ID:                  uint32(C.__get_info_u32(p.handle.api.anon0.get_id)),
+		ExtractEventSources: []string{},
+	}
+	if p.handle.api.get_init_schema != nil {
+		t := (C.ss_plugin_schema_type)(C.SS_PLUGIN_SCHEMA_NONE)
+		s := C.GoString(C.__get_init_schema(&p.handle.api, &t))
+		// todo(jasondellaluce): update this once we support more schema types
+		if t == (C.ss_plugin_schema_type)(C.SS_PLUGIN_SCHEMA_JSON) {
+			p.initSchema = &sdk.SchemaInfo{Schema: s}
+		}
+	}
+
+	// get static info related to extraction capability (if available)
+	if p.HasCapExtraction() && p.handle.api.anon1.get_extract_event_sources != nil {
+		str := C.GoString(C.__get_info_str(p.handle.api.anon1.get_extract_event_sources))
+		if err := json.Unmarshal(([]byte)(str), &p.info.ExtractEventSources); err != nil {
+			// capability is considered not supported if data is corrupted
+			p.caps ^= C.CAP_EXTRACTION
+		}
+	}
+	if p.HasCapExtraction() {
+		str := C.GoString(C.__get_info_str(p.handle.api.anon1.get_fields))
+		if err := json.Unmarshal(([]byte)(str), &p.fields); err != nil {
+			// capability is considered not supported if data is corrupted
+			p.caps ^= C.CAP_EXTRACTION
+		}
+	}
+
+	return p, nil
+}
+
+func (p *Plugin) Unload() {
+	p.m.Lock()
+	defer p.m.Unlock()
+	if p.handle != nil {
+		p.destroy()
+		C.plugin_unload(p.handle)
+		p.handle = nil
+	}
+}
+
+func (p *Plugin) validate() error {
+	if !p.validated {
+		errBuf := (*C.char)(C.malloc(C.uint64_t(C.__plugin_max_errlen) * C.sizeof_char))
+		defer C.free(unsafe.Pointer(errBuf))
+		if !C.plugin_check_required_api_version(p.handle, errBuf) ||
+			!C.plugin_check_required_symbols(p.handle, errBuf) {
+			return errors.New(C.GoString(errBuf))
+		}
+		if p.caps == C.CAP_NONE {
+			return errors.New("plugin supports no capability")
+		}
+		p.validated = true
+	}
+	return p.validErr
+}
+
+func (p *Plugin) Validate() error {
+	p.m.Lock()
+	defer p.m.Unlock()
+	return p.validate()
+}
+
+func (p *Plugin) HasCapExtraction() bool {
+	return p.caps&C.CAP_EXTRACTION != 0
+}
+
+func (p *Plugin) HasCapSourcing() bool {
+	return p.caps&C.CAP_SOURCING != 0
+}
+
+func (p *Plugin) Info() *plugins.Info {
+	return &p.info
+}
+
+func (p *Plugin) InitSchema() *sdk.SchemaInfo {
+	return p.initSchema
+}
+
+func (p *Plugin) Fields() []sdk.FieldEntry {
+	return p.fields
+}
+
+func (p *Plugin) OpenParams() ([]sdk.OpenParam, error) {
+	p.m.Lock()
+	defer p.m.Unlock()
+	if !p.HasCapSourcing() {
+		return nil, errNoSourcingCap
+	}
+	if p.handle.api.anon0.list_open_params == nil {
+		return nil, errors.New("plugin does not implement list_open_params")
+	}
+	if p.state == nil {
+		return nil, errNotInitialized
+	}
+
+	errBuf := (*C.char)(C.malloc(C.uint64_t(C.__plugin_max_errlen) * C.sizeof_char))
+	defer C.free(unsafe.Pointer(errBuf))
+	rc := C.ss_plugin_rc(sdk.SSPluginSuccess)
+	str := C.GoString((C.__list_open_params(&p.handle.api, unsafe.Pointer(p.state), (*C.ss_plugin_rc)(&rc))))
+	if rc != C.ss_plugin_rc(sdk.SSPluginSuccess) {
+		return nil, errors.New(C.GoString(errBuf))
+	}
+
+	var ret []sdk.OpenParam
+	if len(str) > 0 {
+		if err := json.Unmarshal(([]byte)(str), &ret); err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+func (p *Plugin) Init(config string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+	if p.state != nil {
+		return fmt.Errorf("plugin is already initialized")
+	}
+	err := p.validate()
+	if err != nil {
+		return fmt.Errorf("plugin is not valid: %s", err.Error())
+	}
+
+	config, err = p.validateInitConfig(config)
+	if err != nil {
+		return fmt.Errorf("invalid plugin config: %s", err.Error())
+	}
+
+	rc := C.ss_plugin_rc(sdk.SSPluginSuccess)
+	p.state = (*C.ss_plugin_t)(C.__init(&p.handle.api, C.CString(config), (*C.ss_plugin_rc)(&rc)))
+	if rc == C.ss_plugin_rc(sdk.SSPluginSuccess) {
+		return nil
+	}
+	if p.state != nil {
+		err := p.lastError()
+		p.destroy()
+		return err
+	}
+	return errors.New("unknown initialization error")
+}
+
+// only json schemas are supported for now
+func (p *Plugin) validateInitConfig(config string) (string, error) {
+	if p.initSchema != nil {
+		if len(config) == 0 {
+			config = "{}"
+		}
+		schema := gojsonschema.NewStringLoader(p.initSchema.Schema)
+		document := gojsonschema.NewStringLoader(config)
+		result, err := gojsonschema.Validate(schema, document)
+		if err != nil {
+			return "", err
+		}
+		if !result.Valid() {
+			// return fist error
+			return "", errors.New(result.Errors()[0].Description())
+		}
+	}
+	return config, nil
+}
+
+func (p *Plugin) destroy() {
+	if p.state != nil {
+		C.__destroy(&p.handle.api, unsafe.Pointer(p.state))
+		p.state = nil
+	}
+}
+
+func (p *Plugin) lastError() error {
+	if p.state != nil {
+		str := C.GoString(C.__get_last_err(&p.handle.api, unsafe.Pointer(p.state)))
+		if len(str) == 0 {
+			return nil
+		}
+		return errors.New(str)
+	}
+	return errNotInitialized
+}

--- a/pkg/loader/plugin_loader.c
+++ b/pkg/loader/plugin_loader.c
@@ -1,0 +1,237 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#ifdef _WIN32
+    #include <windows.h>
+    typedef HINSTANCE library_handle_t;
+#else
+    #include <dlfcn.h>
+    typedef void* library_handle_t;
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "plugin_loader.h"
+
+static inline void add_str_prefix(char* s, const char* prefix)
+{
+    char tmp[PLUGIN_MAX_ERRLEN];
+    strncpy(tmp, prefix, PLUGIN_MAX_ERRLEN - 1);
+    strncat(tmp, s, PLUGIN_MAX_ERRLEN - 1);
+    strcpy(s, tmp);
+}
+
+static void* getsym(library_handle_t handle, const char* name)
+{
+#ifdef _WIN32
+	return (void*) GetProcAddress(handle, name);
+#else
+	return (void*) dlsym(handle, name);
+#endif
+}
+
+// little hack for simplifying the plugin_load function
+#define SYM_RESOLVE(h, s) \
+    *(void **)(&(h->api.s)) = getsym(h->handle, "plugin_"#s)
+
+plugin_handle_t* plugin_load(const char* path, char* err)
+{
+    // alloc and init memory
+    strcpy(err, "");
+    plugin_handle_t* ret = (plugin_handle_t*) calloc (1, sizeof(plugin_handle_t));
+
+    // open dynamic library
+#ifdef _WIN32
+    ret->handle = LoadLibrary(path);
+    if(ret->handle == NULL)
+    {
+        DWORD flg = FORMAT_MESSAGE_ALLOCATE_BUFFER
+            | FORMAT_MESSAGE_FROM_SYSTEM
+            | FORMAT_MESSAGE_IGNORE_INSERTS;
+        LPTSTR msg_buf = 0;
+        if (FormatMessageA(flg, 0, GetLastError(), 0, (LPTSTR) &msg_buf, 0, NULL) && msg_buf)
+        {
+            strncpy(err, msg_buf, PLUGIN_MAX_ERRLEN -1 );
+            LocalFree(msg_buf);
+        }
+    }
+#else
+    ret->handle = dlopen(path, RTLD_LAZY);
+    if (ret->handle == NULL)
+    {
+        strncpy(err, (const char*) dlerror(), PLUGIN_MAX_ERRLEN - 1);
+    }
+#endif
+
+    // return NULL if library loading had errors
+    if (ret->handle == NULL)
+    {
+        add_str_prefix(err, "can't load plugin dynamic library: ");
+        free(ret);
+        return NULL;
+    }
+
+    // load all library symbols
+    SYM_RESOLVE(ret, get_required_api_version);
+    SYM_RESOLVE(ret, get_version);
+    SYM_RESOLVE(ret, get_last_error);
+    SYM_RESOLVE(ret, get_name);
+    SYM_RESOLVE(ret, get_description);
+    SYM_RESOLVE(ret, get_contact);
+    SYM_RESOLVE(ret, get_init_schema);
+    SYM_RESOLVE(ret, init);
+    SYM_RESOLVE(ret, destroy);
+    SYM_RESOLVE(ret, get_id);
+    SYM_RESOLVE(ret, get_event_source);
+    SYM_RESOLVE(ret, open);
+    SYM_RESOLVE(ret, close);
+    SYM_RESOLVE(ret, next_batch);
+    SYM_RESOLVE(ret, get_progress);
+    SYM_RESOLVE(ret, list_open_params);
+    SYM_RESOLVE(ret, event_to_string);
+    SYM_RESOLVE(ret, get_fields);
+    SYM_RESOLVE(ret, extract_fields);
+    SYM_RESOLVE(ret, get_extract_event_sources);
+    return ret;
+}
+
+void plugin_unload(plugin_handle_t* h)
+{
+    if (h)
+    {
+        if (h->handle)
+        {
+#ifdef _WIN32
+            FreeLibrary(h->handle);
+#else
+            dlclose(h->handle);
+#endif
+        }
+        free(h);
+    }
+}
+
+bool plugin_is_loaded(const char* path)
+{
+#ifdef _WIN32
+	/*
+	 * LoadLibrary maps the module into the address space of the calling process, if necessary,
+	 * and increments the modules reference count, if it is already mapped.
+	 * GetModuleHandle, however, returns the handle to a mapped module
+	 * without incrementing its reference count.
+	 *
+	 * This returns an HMODULE indeed, but they are the same thing
+	 */
+	return GetModuleHandle(path) != NULL;
+#else
+	/*
+	 * RTLD_NOLOAD (since glibc 2.2)
+	 *	Don't load the shared object. This can be used to test if
+	 *	the object is already resident (dlopen() returns NULL if
+	 *	it is not, or the object's handle if it is resident).
+	 *	This does not increment dlobject reference count.
+	 */
+	return dlopen(path, RTLD_LAZY | RTLD_NOLOAD) != NULL;
+#endif
+}
+
+bool plugin_check_required_api_version(const plugin_handle_t* h, char* err)
+{
+    uint32_t major, minor, patch;
+    const char *ver, *failmsg;
+    if (h->api.get_required_api_version == NULL)
+    {
+        strncpy(err, "plugin_get_required_api_version symbol not implemented", PLUGIN_MAX_ERRLEN - 1);
+        return false;
+    }
+
+    ver = h->api.get_required_api_version();
+    if (sscanf(ver, "%" PRIu32 ".%" PRIu32 ".%" PRIu32, &major, &minor, &patch) != 3)
+    {
+        snprintf(err, PLUGIN_MAX_ERRLEN, "plugin provided an invalid required API version: '%s'", ver);
+        return false;
+    }
+
+    failmsg = NULL;
+    if(PLUGIN_API_VERSION_MAJOR != major)
+    {
+        failmsg = "major versions disagree";
+    }
+    else if(PLUGIN_API_VERSION_MINOR < minor)
+    {
+        failmsg = "framework's minor is less than the requested one";
+    }
+    else if(PLUGIN_API_VERSION_MINOR == minor && PLUGIN_API_VERSION_PATCH < patch)
+    {
+        failmsg = "framework's patch is less than the requested one";
+    }
+
+    if (failmsg != NULL)
+    {
+        snprintf(err, PLUGIN_MAX_ERRLEN,
+            "plugin required API version '%s' not compatible with the framework's API version '%s': %s",
+            ver, PLUGIN_API_VERSION_STR, failmsg);
+        return false;
+    }
+
+    return true;
+}
+
+plugin_caps_t plugin_get_capabilities(const plugin_handle_t* h)
+{
+    plugin_caps_t caps = CAP_NONE;
+
+    if (h->api.get_id != NULL
+        && h->api.get_event_source != NULL
+        && h->api.open != NULL
+        && h->api.close != NULL
+        && h->api.next_batch != NULL)
+    {
+        caps = (plugin_caps_t)((uint32_t) caps | (uint32_t) CAP_SOURCING);
+    }
+
+    if (h->api.get_fields != NULL
+        && h->api.extract_fields != NULL)
+    {
+        caps = (plugin_caps_t)((uint32_t) caps | (uint32_t) CAP_EXTRACTION);
+    }
+
+    return caps;
+}
+
+// little hack for simplifying the plugin_check_required_symbols function
+#define SYM_REQCHECK(a, e, s) \
+    do { \
+        if(a->api.s == NULL) \
+        { \
+            snprintf(e, PLUGIN_MAX_ERRLEN, "symbol not implemented: %s", #s); \
+            return false; \
+        } \
+    } while(0)
+
+bool plugin_check_required_symbols(const plugin_handle_t* h, char* err)
+{
+    SYM_REQCHECK(h, err, get_required_api_version);
+    SYM_REQCHECK(h, err, get_version);
+    SYM_REQCHECK(h, err, get_name);
+    SYM_REQCHECK(h, err, get_description);
+    SYM_REQCHECK(h, err, get_contact);
+    SYM_REQCHECK(h, err, init);
+    SYM_REQCHECK(h, err, destroy);
+    SYM_REQCHECK(h, err, get_last_error);
+    return true;
+}

--- a/pkg/loader/plugin_loader.h
+++ b/pkg/loader/plugin_loader.h
@@ -1,0 +1,101 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include "plugin_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*!
+    \brief The maximum length of the error strings written by the plugin loader
+*/
+#define PLUGIN_MAX_ERRLEN 2048
+
+/*!
+    \brief This enums the capabilities supported by plugins.
+    Each plugin can support one or more of these, in which case the enum flags
+    are or-ed with each other.
+    Currently, the supported capabilities are:
+        * ability to source events and provide them to the event loop
+        * ability to extract fields from events created by other plugins
+*/
+typedef enum
+{
+    CAP_NONE        = 0,
+    CAP_SOURCING    = 1 << 0,
+    CAP_EXTRACTION  = 1 << 1
+} plugin_caps_t;
+
+/*!
+    \brief A handle to a loaded plugin dynamic library.
+    Pointers to this struct must be obtained through the plugin_load()
+    and released through plugin_unload().
+*/
+typedef struct plugin_handle_t
+{
+#ifdef _WIN32
+    HINSTANCE handle; ///< Handle of the dynamic library
+#else
+    void* handle; ///< Handle of the dynamic library
+#endif
+    plugin_api api; ///< The vtable method of the plugin that define its API
+} plugin_handle_t;
+
+/*!
+    \brief Loads a dynamic library from the given path and returns a
+    plugin_handle_t* representing the loaded plugin. In case of error,
+    returns NULL and fills the err string up to PLUGIN_MAX_ERRLEN chars.
+*/
+plugin_handle_t* plugin_load(const char* path, char* err);
+
+/*!
+    \brief Destroys a plugin_handle_t* previously allocated by 
+    invoking plugin_load().
+*/
+void plugin_unload(plugin_handle_t* h);
+
+/*!
+    \brief Returns true if the plugin at the given path is currently loaded.
+*/
+bool plugin_is_loaded(const char* path);
+
+/*!
+    \brief Returns true the API version required by the given plugin is
+    compatible with the API version of the loader. Otherwise, returns false
+    and fills the err string up to PLUGIN_MAX_ERRLEN chars.
+*/
+bool plugin_check_required_api_version(const plugin_handle_t* h, char* err);
+
+/*!
+    \brief Returns true if the given plugin handle implements all the
+    minimum required function symbols for the current API version. Otherwise,
+    returns false and fills the err string up to PLUGIN_MAX_ERRLEN chars.
+*/
+bool plugin_check_required_symbols(const plugin_handle_t* h, char* err);
+
+/*!
+    \brief Returns the capabilities supported by the given plugin handle
+*/
+plugin_caps_t plugin_get_capabilities(const plugin_handle_t* h);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

After the changes in libs of https://github.com/falcosecurity/libs/pull/392 (~yet to get merged~), the plugin loading code is isolated in a self-contained package and implements a C api. As such, it is possible to develop loaders in other programming languages by reusing the libs one, which makes it compliant with the targeted libs version out of the box.

This first version of the loader is capable of loading plugins, validating them against the currently-supported plugin API version, and reading all their static/descriptive information (name, version, etc...). The loader is also capable of initializing the plugin in order to read initialization-dependent information such as the list of suggested open params.

**Special notes for your reviewer**:

Blocked and WIP until merging https://github.com/falcosecurity/plugin-sdk-go/pull/63.

Since this PR is already big, unit tests and examples will be added in a future PR. Support for more operations on the loaded plugins will be considered in the future.

Most of the changes are related to pulling `plugin_loader.h/.c` from libs. The actual loader code is ~400 LOC and resides in pkg/loader/loader.go.

**Does this PR introduce a user-facing change?**:

```release-note
new: introduce plugin loader code
```
