### PR TITLE
fix(sdk/symbols/extract): properly calculate starvation time in async extractor

### DIFF
--- a/pkg/sdk/symbols/extract/async.go
+++ b/pkg/sdk/symbols/extract/async.go
@@ -35,8 +35,8 @@ const (
 )
 
 const (
-	starvationThresholdNs = 1e6
-	sleepTimeNs           = 1e4 * time.Nanosecond
+	starvationThresholdNs = int64(1e6)
+	sleepTimeNs           = 1e7 * time.Nanosecond
 )
 
 var (
@@ -91,7 +91,7 @@ func StartAsync() {
 	atomic.StoreInt32((*int32)(&asyncCtx.lock), state_wait)
 	go func() {
 		lock := (*int32)(&asyncCtx.lock)
-		waitStartTime := time.Now().Nanosecond()
+		waitStartTime := time.Now().UnixNano()
 
 		for {
 			// Check for incoming request, if any, otherwise busy waits
@@ -120,8 +120,8 @@ func StartAsync() {
 			default:
 				// busy wait, then sleep after 1ms
 				if waitStartTime == 0 {
-					waitStartTime = time.Now().Nanosecond()
-				} else if time.Now().Nanosecond()-waitStartTime > starvationThresholdNs {
+					waitStartTime = time.Now().UnixNano()
+				} else if time.Now().UnixNano()-waitStartTime > starvationThresholdNs {
 					time.Sleep(sleepTimeNs)
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

This PR fixes the sleeping policy of the async extractor. Currently, the starvation time is not calculated properly, which in the general case can lead to the async worker to never sleep and consume lots of CPU time (I was able to reproduce 100% usage in my setup). With this fix, extraction-intensive use case seem to not be affected performance-wise, whereas plugins where extraction don't happens have just a 1.5%-3% CPU usage overhead if the async extractor is enabled, which is acceptable given its benefits.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
