### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,6 @@
 approvers:
   - leogr
   - jasondellaluce
-reviewers:
-  - leodido
-  - fntlnz
-  - kris-nova
-  - mstemm
-  - leogr
-  - ldegio
-  - jasondellaluce
 emeritus_approvers:
   - leodido
   - fntlnz

--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,5 @@
 approvers:
-  - leodido
-  - fntlnz
-  - kris-nova
-  - mstemm
   - leogr
-  - ldegio
   - jasondellaluce
 reviewers:
   - leodido
@@ -14,3 +9,9 @@ reviewers:
   - leogr
   - ldegio
   - jasondellaluce
+emeritus_approvers:
+  - leodido
+  - fntlnz
+  - kris-nova
+  - mstemm
+  - ldegio


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
