### PR TITLE
update(OWNERS): move inactive maintainers to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,10 @@
 approvers:
+  - leogr
+  - jasondellaluce
+emeritus_approvers:
   - leodido
   - fntlnz
   - kris-nova
   - mstemm
-  - leogr
   - ldegio
-  - jasondellaluce
-reviewers:
-  - leodido
-  - fntlnz
-  - kris-nova
-  - mstemm
-  - leogr
-  - ldegio
-  - jasondellaluce
+  


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR supersedes #58 since it is blocked by a reviewer "change request". 

Note that all the maintainers moved to emeritus have been:
- inactive in the last 6 months,
- stepped down,
- or never contributed to this repository


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
