### PR TITLE
refactor(pkg/sdk/symbols/extract): support concurrent consumers in async extraction optimization

### DIFF
--- a/pkg/sdk/symbols/extract/async.go
+++ b/pkg/sdk/symbols/extract/async.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sdk/symbols/extract/async.go
+++ b/pkg/sdk/symbols/extract/async.go
@@ -21,11 +21,21 @@ package extract
 */
 import "C"
 import (
+	"math"
+	"reflect"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
+
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
 )
+
+// note: this package is aware and dependent on the current implementation
+// of our cgo package. See doc comment of asyncCtxBatch for more context.
+// todo(jasondellaluce): change this (and extract.c) if we change the
+// current cgo.Handle implementation
 
 const (
 	state_wait = iota
@@ -40,22 +50,174 @@ const (
 )
 
 var (
-	asyncCtx     *C.async_extractor_info
-	asyncMutex   sync.Mutex
-	asyncEnabled bool  = true
-	asyncCount   int32 = 0
+	// asyncEnabled is true if the async optimization is configured
+	// to be enabled
+	asyncEnabled bool = true
+	//
+	// asyncMutex ensures that StartAsync and StopAsync are used with mutual
+	// exclusion
+	asyncMutex sync.Mutex
+	//
+	// asyncCount is incremented at every call to StartAsync and
+	// is decremented at every call to StopAsync
+	asyncCount int32 = 0
+	//
+	// asyncCtxBatch is a batch of async info contexts that is shared between
+	// C and Go. Each slot of the batch contains a unique lock and is assigned
+	// to only one cgo.Handle value.
+	//
+	// note(jasondellaluce): this is dependent on our internal implementation
+	// of cgo.Handle. Since cgo.Handle values are regular integers between 1
+	// and cgo.MaxHandle, they are used to assign the batch slot index to
+	// each consumer. Each initialized plugin is a distinct consumer and has
+	// its own assigned cgo.Handle value.
+	// I don't like leaking this implementation knowledge of our cgo package,
+	// however the goal here is to achieve maximum performance and using
+	// array-based access is the best we can get.
+	//
+	asyncCtxBatch []C.async_extractor_info
+	//
+	// asyncCtxBatchCap is the physical size of asyncCtxBatch as allocated
+	// in C memory, namely the total number of slots available
+	asyncCtxBatchCap = cgo.MaxHandle + 1
+	//
+	// asyncCtxBatchLen is the number of occupied slots of asyncCtxBatch.
+	// This value is >= 0 and < asyncCtxBatchCap. The solely purpose of
+	// counting the number of occupied lock slots is for the worker to avoid
+	// looping over the whole batch when only few slots are really used, so that
+	// the synchronization overhead is minimized in that point.
+	// This value is incremented at every call to StartAsync and is
+	// never decremented. The reason is that the value spaces for cgo.Handle
+	// can become sparse when a plugin is destroyed and its cgo.Handle deleted.
+	// We can assume already-assigned cgo.Handles to be reused after deletion,
+	// but we can't make assumptions on which is the largest cgo.Handle used in
+	// a given moment, so we have to loop and synchronize up until the
+	// highest-index slot. This is set to zero at the last call to StopAsync
+	// right after all the async workers are stopped.
+	asyncCtxBatchLen = int32(0)
 )
 
+// TODO: make this configurable and thread-safe
+const maxWorkers = int32(6)
+
+// since on high workloads an async worker can potentially occupy a whole
+// thread (and its CPU), we consider the optimization available only if
+// we run on at least 2 CPUs.
 func asyncAvailable() bool {
-	return runtime.NumCPU() > 1
+	// note: runtime.GOMAXPROCS(0) should be more accurate than runtime.NumCPU()
+	// and and better aligns with the developer/user thread pool configuration.
+	//
+	// TODO: how do we prevent the plugin from breaking if
+	// runtime.GOMAXPROCS(0) is changed after starting the async workers?
+	return runtime.GOMAXPROCS(0) > 1
 }
 
+// SetAsync enables or disables the async extraction optimization depending
+// on the passed-in boolean.
+//
+// Note, setting the optimization as enabled does
+// not guarantee that it will be used at runtime, as the SDK will first check
+// if the hardware configuration matches the minimum requirements.
 func SetAsync(enable bool) {
+	// TODO: is it ok to call this at every plugin_init()?
 	asyncEnabled = enable
 }
 
+// Async returns true if the async extraction optimization is
+// configured to be enabled, and false otherwise.
 func Async() bool {
 	return asyncEnabled
+}
+
+func initAsyncCtxBatch() {
+	// initialize the batch in C memory
+	batch := unsafe.Pointer(C.async_init((C.size_t)(asyncCtxBatchCap)))
+
+	// convert the batch into a Go slice
+	(*reflect.SliceHeader)(unsafe.Pointer(&asyncCtxBatch)).Data = uintptr(batch)
+	(*reflect.SliceHeader)(unsafe.Pointer(&asyncCtxBatch)).Len = int(asyncCtxBatchCap)
+	(*reflect.SliceHeader)(unsafe.Pointer(&asyncCtxBatch)).Cap = int(asyncCtxBatchCap)
+
+	// initialize all the locks in the batch
+	for i := 0; i < asyncCtxBatchCap; i++ {
+		atomic.StoreInt32((*int32)(&asyncCtxBatch[i].lock), state_wait)
+	}
+}
+
+func destroyAsyncCtxBatch() {
+	asyncCtxBatch = nil
+	atomic.StoreInt32(&asyncCtxBatchLen, 0)
+	C.async_deinit()
+}
+
+func startWorker(workerIdx int32) {
+	waitStartTime := time.Now().UnixNano()
+	for {
+		// Loop over async context batch slots in round-robin.
+		//
+		// Note: workers are assigned an integer index and will just loop
+		// over slots at positions at (workerIndex + maxWorkers * i). This
+		// ensures that multiple async workers never collide trying to sync
+		// on the same slot. To prevent starvation on all slots, a new async
+		// worker is spawned every time a new slot gets used up until the
+		// max number of workers. Then, workers are not stopped until all the
+		// slots become unused, which happens at the last call to StopAsync.
+		// The logic is similar to the one documented for asyncCtxBatchLen.
+		//
+		// For example, assuming a maximum number of 3 workers:
+		//   - Worker 0 will sync over slots: 0, 3, 6, 9, ...
+		//   - Worker 1 will sync over slots: 1, 4, 7, 10, ...
+		//   - Worker 2 will sync over slots: 2, 5, 8, 11, ...
+		for i := int32(workerIdx); i < atomic.LoadInt32(&asyncCtxBatchLen); i += maxWorkers {
+			// Check for incoming request, if any, otherwise busy waits
+			switch atomic.LoadInt32((*int32)(&asyncCtxBatch[i].lock)) {
+
+			case state_data_req:
+				// Incoming data request. Process it...
+				asyncCtxBatch[i].rc = C.int32_t(
+					plugin_extract_fields_sync(
+						C.uintptr_t(uintptr(asyncCtxBatch[i].s)),
+						asyncCtxBatch[i].evt,
+						uint32(asyncCtxBatch[i].num_fields),
+						asyncCtxBatch[i].fields,
+					),
+				)
+				// Processing done, return back to waiting state
+				atomic.StoreInt32((*int32)(&asyncCtxBatch[i].lock), state_wait)
+				// Reset waiting start time
+				waitStartTime = 0
+
+			case state_exit_req:
+				// Incoming exit request. Send ack and exit.
+				atomic.StoreInt32((*int32)(&asyncCtxBatch[i].lock), state_exit_ack)
+				return
+			}
+
+			// busy wait, then sleep after 1ms
+			if waitStartTime == 0 {
+				waitStartTime = time.Now().UnixNano()
+			} else if time.Now().UnixNano()-waitStartTime > starvationThresholdNs {
+				time.Sleep(sleepTimeNs)
+			}
+		}
+	}
+}
+
+// note: this is called only at the last call to StopAsync, so it's safe to
+// assume that all the batch slots are unused (in wait state). So, we make a
+// stop request from the Go side on the first slot visible by the given worker.
+// The worker will stop after resolving the first exit request.
+func stopWorker(workerIdx int32) {
+	for !atomic.CompareAndSwapInt32((*int32)(&asyncCtxBatch[workerIdx].lock), state_wait, state_exit_req) {
+		// spin
+	}
+
+	// state_exit_req acquired, wait for worker exiting
+	for atomic.LoadInt32((*int32)(&asyncCtxBatch[workerIdx].lock)) != state_exit_ack {
+		// spin
+	}
+
+	atomic.StoreInt32((*int32)(&asyncCtxBatch[workerIdx].lock), state_wait)
 }
 
 // StartAsync initializes and starts the asynchronous extraction mode.
@@ -78,81 +240,53 @@ func Async() bool {
 // After calling StartAsync, the framework automatically shift the extraction
 // strategy from the regular C -> Go call one to the alternative worker
 // synchronization one.
-func StartAsync() {
+func StartAsync(handle cgo.Handle) {
 	asyncMutex.Lock()
 	defer asyncMutex.Unlock()
 
 	asyncCount += 1
-	if !asyncAvailable() || !asyncEnabled || asyncCount > 1 {
+	println("start", asyncCount)
+	if !asyncAvailable() || !asyncEnabled {
 		return
 	}
 
-	asyncCtx = C.async_init()
-	atomic.StoreInt32((*int32)(&asyncCtx.lock), state_wait)
-	go func() {
-		lock := (*int32)(&asyncCtx.lock)
-		waitStartTime := time.Now().UnixNano()
+	if asyncCount == 1 {
+		initAsyncCtxBatch()
+	}
 
-		for {
-			// Check for incoming request, if any, otherwise busy waits
-			switch atomic.LoadInt32(lock) {
+	// newBatchLen represents the number of batch slots currently used, which
+	// also equals to the maximum cgo.Handle value assigned so far.
+	// Since cgo.Handle values can be reused when a plugin is initialized and
+	// then destroyed, newBatchLen is the max value between the currently-known
+	// max cgo.Handle value (asyncCtxBatchLen) and the current one.
+	newBatchLen := int32(math.Max(float64(handle), float64(atomic.LoadInt32(&asyncCtxBatchLen))))
+	atomic.StoreInt32(&asyncCtxBatchLen, newBatchLen)
 
-			case state_data_req:
-				// Incoming data request. Process it...
-				asyncCtx.rc = C.int32_t(
-					plugin_extract_fields_sync(
-						C.uintptr_t(uintptr(asyncCtx.s)),
-						asyncCtx.evt,
-						uint32(asyncCtx.num_fields),
-						asyncCtx.fields,
-					),
-				)
-				// Processing done, return back to waiting state
-				atomic.StoreInt32(lock, state_wait)
-				// Reset waiting start time
-				waitStartTime = 0
-
-			case state_exit_req:
-				// Incoming exit request. Send ack and exit.
-				atomic.StoreInt32(lock, state_exit_ack)
-				return
-
-			default:
-				// busy wait, then sleep after 1ms
-				if waitStartTime == 0 {
-					waitStartTime = time.Now().UnixNano()
-				} else if time.Now().UnixNano()-waitStartTime > starvationThresholdNs {
-					time.Sleep(sleepTimeNs)
-				}
-			}
-		}
-	}()
+	// spawn a new async worker for each new batch slot used up until the max
+	// possible number of workers
+	if newBatchLen-1 < maxWorkers {
+		// note: worker indexes are 0-based and the batch len is > 1 here
+		go startWorker(newBatchLen - 1)
+	}
 }
 
 // StopAsync deinitializes and stops the asynchronous extraction mode, and
 // undoes a single StartAsync call. It is a run-time error if StartAsync was
 // not called before calling StopAsync.
-func StopAsync() {
+func StopAsync(handle cgo.Handle) {
 	asyncMutex.Lock()
 	defer asyncMutex.Unlock()
 
 	asyncCount -= 1
+	println("stop", asyncCount)
 	if asyncCount < 0 {
 		panic("plugin-sdk-go/sdk/symbols/extract: async worker stopped without being started")
 	}
 
-	if asyncCount == 0 && asyncCtx != nil {
-		lock := (*int32)(&asyncCtx.lock)
-
-		for !atomic.CompareAndSwapInt32(lock, state_wait, state_exit_req) {
-			// spin
+	if asyncCtxBatch != nil && asyncCount == 0 {
+		for i := int32(0); i < maxWorkers && i < asyncCtxBatchLen; i++ {
+			stopWorker(i)
 		}
-
-		// state_exit_req acquired, wait for worker exiting
-		for atomic.LoadInt32(lock) != state_exit_ack {
-			// spin
-		}
-		asyncCtx = nil
-		C.async_deinit()
+		destroyAsyncCtxBatch()
 	}
 }

--- a/pkg/sdk/symbols/extract/async.go
+++ b/pkg/sdk/symbols/extract/async.go
@@ -254,6 +254,9 @@ func stopWorker(workerIdx int32) {
 			// spin
 		}
 
+		// restore slot lock to unused state
+		atomic.StoreInt32((*int32)(&asyncCtxBatch[idx].lock), state_unused)
+
 		activeWorkers[workerIdx] = false
 		return
 	}

--- a/pkg/sdk/symbols/extract/async.go
+++ b/pkg/sdk/symbols/extract/async.go
@@ -21,7 +21,7 @@ package extract
 */
 import "C"
 import (
-	"math"
+	"fmt"
 	"reflect"
 	"runtime"
 	"sync"
@@ -32,21 +32,64 @@ import (
 	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
 )
 
+//
+// The code below implements of the async extraction optimization.
+// Our goal is to defeat the C -> Go calls overhead and achieve better
+// performance during the field extraction path, which is one of the hottest
+// of in the plugin framework.
+//
+// The design follows the P3-S4 solution documented in the discussion of
+// https://github.com/falcosecurity/plugin-sdk-go/issues/62.
+// We have N concurrent consumers from the C world, N locks shared between C
+// and Go, and M async workers in the Go world. The shared spinlocks are the
+// point of synchronization between the C consumers and the Go workers.
+// There is a 1-1 mapping between a C consumer and a shared lock, so there
+// are no collisions between consumers on the same lock. As such, each consumer
+// will be served always by the same one worker. On the countrary, each worker
+// synchronizes with 1+ locks (and consumers), with a given rotation policy.
+// The number of workers M, is not necessarily correlated con the number
+// of consumers N. Note, each worker heavily occupies the CPU for small time
+// bursts so M should be less than runtime.GOMAXPROCS.
+//
+// Each worker has an integer index and will just loop over slots at positions
+// at (workerIndex + maxWorkers * i). This ensures that multiple async workers
+// never collide trying to sync on the same slot.
+// For example, assuming a maximum number of 3 workers:
+//   - Worker 0 will sync over batch slots: 0, 3, 6, 9, ...
+//   - Worker 1 will sync over batch slots: 1, 4, 7, 10, ...
+//   - Worker 2 will sync over batch slots: 2, 5, 8, 11, ...
+//
 // note: this package is aware and dependent on the current implementation
-// of our cgo package. See doc comment of asyncCtxBatch for more context.
-// todo(jasondellaluce): change this (and extract.c) if we change the
-// current cgo.Handle implementation
+// of our cgo package. Since cgo.Handle values are regular integers between 1
+// and cgo.MaxHandle, they are used to assign the batch slot index to
+// each consumer. Each initialized plugin is a distinct consumer and has
+// its own assigned cgo.Handle value. I really don't like leaking this
+// implementation knowledge of our cgo package, however the goal here is to
+// reach maximum performance and using array-based access is our best option.
+//
+// todo(jasondellaluce): change this and extract.c if we change the current
+// cgo.Handle implementation
 
 const (
-	state_wait = iota
-	state_data_req
-	state_exit_req
-	state_exit_ack
+	state_unused   = iota // the lock is unused
+	state_wait            // the lock is free and a new request can be sent
+	state_data_req        // an extraction request has been sent by the consumer
+	state_exit_req        // an exit request has been sent by the consumer
+	state_exit_ack        // an exit request has been resolved by the worker
 )
 
 const (
+	// starvationThresholdNs is the time in nanoseconds on which async workers
+	// can be in busy-loop without going to sleep
 	starvationThresholdNs = int64(1e6)
-	sleepTimeNs           = 1e7 * time.Nanosecond
+	//
+	// sleepTimeNs is the sleep time in nanoseconds for async workers
+	// after busy-looping for starvationThresholdNs time
+	sleepTimeNs = 1e7 * time.Nanosecond
+	//
+	// asyncCtxBatchCap is the physical size of asyncCtxBatch as allocated
+	// in C memory, namely the total number of locks available
+	asyncCtxBatchCap = cgo.MaxHandle + 1
 )
 
 var (
@@ -63,61 +106,32 @@ var (
 	asyncCount int32 = 0
 	//
 	// asyncCtxBatch is a batch of async info contexts that is shared between
-	// C and Go. Each slot of the batch contains a unique lock and is assigned
+	// C and Go. Each slot of the batch contains a distinct lock and is assigned
 	// to only one cgo.Handle value.
-	//
-	// note(jasondellaluce): this is dependent on our internal implementation
-	// of cgo.Handle. Since cgo.Handle values are regular integers between 1
-	// and cgo.MaxHandle, they are used to assign the batch slot index to
-	// each consumer. Each initialized plugin is a distinct consumer and has
-	// its own assigned cgo.Handle value.
-	// I don't like leaking this implementation knowledge of our cgo package,
-	// however the goal here is to achieve maximum performance and using
-	// array-based access is the best we can get.
 	//
 	asyncCtxBatch []C.async_extractor_info
 	//
-	// asyncCtxBatchCap is the physical size of asyncCtxBatch as allocated
-	// in C memory, namely the total number of slots available
-	asyncCtxBatchCap = cgo.MaxHandle + 1
+	// activeWorkers entries are true if an async worker is currently active
+	// at the given index. The size of activeWorkers is maxWorkers.
+	activeWorkers = [maxWorkers]bool{}
 	//
-	// asyncCtxBatchLen is the number of occupied slots of asyncCtxBatch.
-	// This value is >= 0 and < asyncCtxBatchCap. The solely purpose of
-	// counting the number of occupied lock slots is for the worker to avoid
-	// looping over the whole batch when only few slots are really used, so that
-	// the synchronization overhead is minimized in that point.
-	// This value is incremented at every call to StartAsync and is
-	// never decremented. The reason is that the value spaces for cgo.Handle
-	// can become sparse when a plugin is destroyed and its cgo.Handle deleted.
-	// We can assume already-assigned cgo.Handles to be reused after deletion,
-	// but we can't make assumptions on which is the largest cgo.Handle used in
-	// a given moment, so we have to loop and synchronize up until the
-	// highest-index slot. This is set to zero at the last call to StopAsync
-	// right after all the async workers are stopped.
-	asyncCtxBatchLen = int32(0)
+	// maxBatchIdx is the greatest slot index occupied in the batch.
+	// This value is >= 0 and < asyncCtxBatchCap. This is used by async workers
+	// to avoid looping over batch slots that are known to be unused in order to
+	// minimize the synchronization overhead.
+	maxBatchIdx = int32(0)
 )
 
+// maxWorkers is the max number of workers that can be active at the same time
 // TODO: make this configurable and thread-safe
-const maxWorkers = int32(6)
-
-// since on high workloads an async worker can potentially occupy a whole
-// thread (and its CPU), we consider the optimization available only if
-// we run on at least 2 CPUs.
-func asyncAvailable() bool {
-	// note: runtime.GOMAXPROCS(0) should be more accurate than runtime.NumCPU()
-	// and and better aligns with the developer/user thread pool configuration.
-	//
-	// TODO: how do we prevent the plugin from breaking if
-	// runtime.GOMAXPROCS(0) is changed after starting the async workers?
-	return runtime.GOMAXPROCS(0) > 1
-}
+const maxWorkers = int32(3)
 
 // SetAsync enables or disables the async extraction optimization depending
 // on the passed-in boolean.
 //
-// Note, setting the optimization as enabled does
-// not guarantee that it will be used at runtime, as the SDK will first check
-// if the hardware configuration matches the minimum requirements.
+// Note, setting the optimization as enabled does not guarantee that it will
+// be actually used at runtime, as the SDK will first check whether the hardware
+// configuration matches some minimum requirements.
 func SetAsync(enable bool) {
 	// TODO: is it ok to call this at every plugin_init()?
 	asyncEnabled = enable
@@ -129,51 +143,79 @@ func Async() bool {
 	return asyncEnabled
 }
 
-func initAsyncCtxBatch() {
-	// initialize the batch in C memory
-	batch := unsafe.Pointer(C.async_init((C.size_t)(asyncCtxBatchCap)))
+// since on high workloads an async worker can potentially occupy a whole
+// thread (and its CPU), we consider the optimization available only if
+// we run on at least 2 CPUs.
+func asyncAvailable() bool {
+	// note: runtime.GOMAXPROCS(0) should be more accurate than runtime.NumCPU()
+	// and and better aligns with the developer/user thread pool configuration.
+	//
+	// TODO: how do we prevent the plugin from breaking if
+	// runtime.GOMAXPROCS(0) is changed after starting the async workers?
+	// IDEA: make this a var boolean and set this while initializing the batch
+	return runtime.GOMAXPROCS(0) > 1
+}
 
-	// convert the batch into a Go slice
+func initAsyncCtxBatch() {
+	// initialize the batch in C memory and convert the batch into a Go slice
+	batch := unsafe.Pointer(C.async_init((C.size_t)(asyncCtxBatchCap)))
 	(*reflect.SliceHeader)(unsafe.Pointer(&asyncCtxBatch)).Data = uintptr(batch)
 	(*reflect.SliceHeader)(unsafe.Pointer(&asyncCtxBatch)).Len = int(asyncCtxBatchCap)
 	(*reflect.SliceHeader)(unsafe.Pointer(&asyncCtxBatch)).Cap = int(asyncCtxBatchCap)
 
-	// initialize all the locks in the batch
+	// initialize all the locks in the batch as unused for now
 	for i := 0; i < asyncCtxBatchCap; i++ {
-		atomic.StoreInt32((*int32)(&asyncCtxBatch[i].lock), state_wait)
+		atomic.StoreInt32((*int32)(&asyncCtxBatch[i].lock), state_unused)
 	}
+
+	// no worker is active at the beginning
+	for i := int32(0); i < maxWorkers; i++ {
+		activeWorkers[i] = false
+	}
+
+	// no batch index is used at the beginning
+	atomic.StoreInt32(&maxBatchIdx, 0)
 }
 
 func destroyAsyncCtxBatch() {
 	asyncCtxBatch = nil
-	atomic.StoreInt32(&asyncCtxBatchLen, 0)
 	C.async_deinit()
+}
+
+// 1 batch slot maps to only 1 worker
+func batchIdxToWorkerIdx(slotIdx int32) int32 {
+	return slotIdx % maxWorkers
+}
+
+// 1 worker maps to 1+ batch slots
+func workerIdxToBatchIdxs(workerIdx int32) []int32 {
+	var res []int32
+	for i := int32(workerIdx); i < int32(asyncCtxBatchCap); i += maxWorkers {
+		res = append(res, i)
+	}
+	return res
+}
+
+func handleToBatchIdx(h cgo.Handle) int32 {
+	return int32(h) - 1
 }
 
 func startWorker(workerIdx int32) {
 	waitStartTime := time.Now().UnixNano()
+	batchIdxs := workerIdxToBatchIdxs(workerIdx)
 	for {
-		// Loop over async context batch slots in round-robin.
-		//
-		// Note: workers are assigned an integer index and will just loop
-		// over slots at positions at (workerIndex + maxWorkers * i). This
-		// ensures that multiple async workers never collide trying to sync
-		// on the same slot. To prevent starvation on all slots, a new async
-		// worker is spawned every time a new slot gets used up until the
-		// max number of workers. Then, workers are not stopped until all the
-		// slots become unused, which happens at the last call to StopAsync.
-		// The logic is similar to the one documented for asyncCtxBatchLen.
-		//
-		// For example, assuming a maximum number of 3 workers:
-		//   - Worker 0 will sync over slots: 0, 3, 6, 9, ...
-		//   - Worker 1 will sync over slots: 1, 4, 7, 10, ...
-		//   - Worker 2 will sync over slots: 2, 5, 8, 11, ...
-		for i := int32(workerIdx); i < atomic.LoadInt32(&asyncCtxBatchLen); i += maxWorkers {
-			// Check for incoming request, if any, otherwise busy waits
+		// ;oop over async context batch slots in round-robin
+		for _, i := range batchIdxs {
+			// reduce sync overhead by skipping unused batch slots
+			if i > maxBatchIdx {
+				continue
+			}
+
+			// check for incoming request, if any, otherwise busy waits
 			switch atomic.LoadInt32((*int32)(&asyncCtxBatch[i].lock)) {
 
 			case state_data_req:
-				// Incoming data request. Process it...
+				// incoming data request, process it...
 				asyncCtxBatch[i].rc = C.int32_t(
 					plugin_extract_fields_sync(
 						C.uintptr_t(uintptr(asyncCtxBatch[i].s)),
@@ -182,9 +224,9 @@ func startWorker(workerIdx int32) {
 						asyncCtxBatch[i].fields,
 					),
 				)
-				// Processing done, return back to waiting state
+				// processing done, return back to waiting state
 				atomic.StoreInt32((*int32)(&asyncCtxBatch[i].lock), state_wait)
-				// Reset waiting start time
+				// reset waiting start time
 				waitStartTime = 0
 
 			case state_exit_req:
@@ -203,90 +245,134 @@ func startWorker(workerIdx int32) {
 	}
 }
 
-// note: this is called only at the last call to StopAsync, so it's safe to
-// assume that all the batch slots are unused (in wait state). So, we make a
-// stop request from the Go side on the first slot visible by the given worker.
-// The worker will stop after resolving the first exit request.
+// note: this has to be called only if all the batch slots visible to a worker
+// are currently unused. So, we make a stop request from the Go side on the
+// first used slot visible by the given worker. The worker will stop after
+// resolving the first exit request.
 func stopWorker(workerIdx int32) {
-	for !atomic.CompareAndSwapInt32((*int32)(&asyncCtxBatch[workerIdx].lock), state_wait, state_exit_req) {
-		// spin
-	}
+	if activeWorkers[workerIdx] {
+		idx := workerIdxToBatchIdxs(workerIdx)[0]
+		for !atomic.CompareAndSwapInt32((*int32)(&asyncCtxBatch[idx].lock), state_unused, state_exit_req) {
+			// spin
+		}
 
-	// state_exit_req acquired, wait for worker exiting
-	for atomic.LoadInt32((*int32)(&asyncCtxBatch[workerIdx].lock)) != state_exit_ack {
-		// spin
-	}
+		// state_exit_req acquired, wait for worker exiting
+		for atomic.LoadInt32((*int32)(&asyncCtxBatch[idx].lock)) != state_exit_ack {
+			// spin
+		}
 
-	atomic.StoreInt32((*int32)(&asyncCtxBatch[workerIdx].lock), state_wait)
+		activeWorkers[workerIdx] = false
+		return
+	}
 }
 
-// StartAsync initializes and starts the asynchronous extraction mode.
-// Once StartAsync has been called, StopAsync must be called before terminating
-// the program. The number of calls to StartAsync and StopAsync must be equal
-// in the program. Independently by the number of StartAsync/StopAsync calls,
-// there will never be more than one async worker activated at the same time.
+// StartAsync initializes and starts the asynchronous extraction mode for the
+// given plugin handle. Once StartAsync has been called, StopAsync must be
+// called before terminating the program. The number of calls to StartAsync
+// and StopAsync must be equal in the program.
 //
 // This is a way to optimize field extraction for use cases in which the rate
 // of calls to plugin_extract_fields() is considerably high, so that the
 // overhead of the C -> Go calls may become unacceptable for performance.
-// Asynchronous extraction solves this problem by launching a worker
-// goroutine and by synchronizing with it through a spinlock.
-// The worker implements a busy wait, in order to ensure that the scheduler
+// Asynchronous extraction solves this problem by launching worker
+// goroutines and by synchronizing with them through shared spinlocks.
+// Each worker implements a busy wait, in order to ensure that the scheduler
 // sleeps it from its execution as less as possible. This is only suitable
 // for multi-core architectures, and has a significant impact on CPU usage,
 // so it should be carefully used only if the rate of C -> Go calls makes
 // the tradeoff worth it.
 //
-// After calling StartAsync, the framework automatically shift the extraction
-// strategy from the regular C -> Go call one to the alternative worker
-// synchronization one.
+// The behavior of StartAsync is influenced by the value set through SetAsync:
+// if set to true the SDK will attempt to run the optimization depending on
+// the underlying hardware capacity, otherwise this will have no effect.
+// After calling StartAsync with SetAsync set to true, the framework will try to
+// automatically shift the extraction strategy from the regular C -> Go call
+// one to the alternative worker synchronization one.
 func StartAsync(handle cgo.Handle) {
 	asyncMutex.Lock()
 	defer asyncMutex.Unlock()
 
 	asyncCount += 1
-	println("start", asyncCount)
 	if !asyncAvailable() || !asyncEnabled {
 		return
 	}
 
-	if asyncCount == 1 {
+	// init the batch if we haven't already
+	if asyncCount >= 1 && asyncCtxBatch == nil {
 		initAsyncCtxBatch()
 	}
 
-	// newBatchLen represents the number of batch slots currently used, which
-	// also equals to the maximum cgo.Handle value assigned so far.
-	// Since cgo.Handle values can be reused when a plugin is initialized and
-	// then destroyed, newBatchLen is the max value between the currently-known
-	// max cgo.Handle value (asyncCtxBatchLen) and the current one.
-	newBatchLen := int32(math.Max(float64(handle), float64(atomic.LoadInt32(&asyncCtxBatchLen))))
-	atomic.StoreInt32(&asyncCtxBatchLen, newBatchLen)
+	// assign a batch slot to this handle
+	// each handle has a 1-1 mapping with a batch slot
+	batchIdx := handleToBatchIdx(handle)
+	atomic.StoreInt32((*int32)(&asyncCtxBatch[batchIdx].lock), state_wait)
+	if batchIdx > atomic.LoadInt32(&maxBatchIdx) {
+		atomic.StoreInt32(&maxBatchIdx, batchIdx)
+	}
 
-	// spawn a new async worker for each new batch slot used up until the max
-	// possible number of workers
-	if newBatchLen-1 < maxWorkers {
-		// note: worker indexes are 0-based and the batch len is > 1 here
-		go startWorker(newBatchLen - 1)
+	// spawn a worker for this handle, if not already active
+	workerIdx := batchIdxToWorkerIdx(batchIdx)
+	if !activeWorkers[workerIdx] {
+		go startWorker(workerIdx)
+		activeWorkers[workerIdx] = true
 	}
 }
 
-// StopAsync deinitializes and stops the asynchronous extraction mode, and
-// undoes a single StartAsync call. It is a run-time error if StartAsync was
-// not called before calling StopAsync.
+// StopAsync deinitializes the asynchronous extraction mode for the given plugin
+// handle, and undoes a single previous StartAsync call. It is a run-time error
+// if StartAsync was not called before calling StopAsync.
 func StopAsync(handle cgo.Handle) {
 	asyncMutex.Lock()
 	defer asyncMutex.Unlock()
 
 	asyncCount -= 1
-	println("stop", asyncCount)
 	if asyncCount < 0 {
 		panic("plugin-sdk-go/sdk/symbols/extract: async worker stopped without being started")
 	}
 
-	if asyncCtxBatch != nil && asyncCount == 0 {
-		for i := int32(0); i < maxWorkers && i < asyncCtxBatchLen; i++ {
-			stopWorker(i)
+	if asyncCtxBatch != nil {
+		// update the state vars if this handle used async extraction
+		batchIdx := handleToBatchIdx(handle)
+		if atomic.LoadInt32((*int32)(&asyncCtxBatch[batchIdx].lock)) != state_unused {
+			// set the assigned batch slot as unused
+			atomic.StoreInt32((*int32)(&asyncCtxBatch[batchIdx].lock), state_unused)
+
+			// check all the batch slots assigned to the worker,
+			// and stop it if all of them are unused
+			workerNeeded := false
+			workerIdx := batchIdxToWorkerIdx(batchIdx)
+			for _, i := range workerIdxToBatchIdxs(workerIdx) {
+				if atomic.LoadInt32((*int32)(&asyncCtxBatch[i].lock)) != state_unused {
+					workerNeeded = true
+					break
+				}
+			}
+			if !workerNeeded {
+				stopWorker(workerIdx)
+			}
+
+			// update the current maximum used slot, so that async workers
+			// will not try to sync over this index
+			if batchIdx == atomic.LoadInt32(&maxBatchIdx) {
+				for i := int32(batchIdx) - 1; i >= 0; i-- {
+					if atomic.LoadInt32((*int32)(&asyncCtxBatch[i].lock)) != state_unused {
+						atomic.StoreInt32(&maxBatchIdx, i)
+						break
+					}
+				}
+			}
 		}
-		destroyAsyncCtxBatch()
+
+		// if this was the last handle to be destroyed,
+		// then we can safely destroy the batch too
+		if asyncCount == 0 {
+			// all workers should already be stopped by now
+			for i := int32(0); i < maxWorkers; i++ {
+				if activeWorkers[i] {
+					panic(fmt.Sprintf("plugin-sdk-go/sdk/symbols/extract: worker %d can't be stopped", i))
+				}
+			}
+			destroyAsyncCtxBatch()
+		}
 	}
 }

--- a/pkg/sdk/symbols/extract/async_test.go
+++ b/pkg/sdk/symbols/extract/async_test.go
@@ -16,14 +16,213 @@ limitations under the License.
 
 package extract
 
-import "testing"
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"unsafe"
 
-func TestGetMaxWorkers(t *testing.T) {
+	"github.com/falcosecurity/plugin-sdk-go/pkg/cgo"
+	"github.com/falcosecurity/plugin-sdk-go/pkg/sdk"
+)
+
+type sampleAsyncExtract struct {
+	sampleExtract
+	counter uint64
+}
+
+func (s *sampleAsyncExtract) Extract(req sdk.ExtractRequest, evt sdk.EventReader) error {
+	req.SetValue(s.counter)
+	s.counter++
+	return nil
+}
+
+func testAllocAsyncBatch() []_Ctype_async_extractor_info {
+	return make([]_Ctype_async_extractor_info, asyncBatchSize)
+}
+
+func testReleaseAsyncBatch(c []_Ctype_async_extractor_info) {}
+
+func TestSetAsync(t *testing.T) {
+	a := asyncContext{}
+	if !a.Async() {
+		t.Fatalf("Async returned %v but expected %v", false, true)
+	}
+
+	a.SetAsync(false)
+	if a.Async() {
+		t.Fatalf("Async returned %v but expected %v", true, false)
+	}
+
+	a.SetAsync(true)
+	if !a.Async() {
+		t.Fatalf("Async returned %v but expected %v", false, true)
+	}
+}
+
+func TestAsyncGetMaxWorkers(t *testing.T) {
+	a := asyncContext{}
 	expected := []int32{0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5}
 	for i, ex := range expected {
-		v := getMaxWorkers(i + 1)
+		v := a.getMaxWorkers(i + 1)
 		if v != ex {
 			t.Fatalf("getMaxWorkers returned %d but expected %d", v, ex)
 		}
 	}
+}
+
+func TestAsyncBatchIdxWorkerIdx(t *testing.T) {
+	for maxWorkers := 1; maxWorkers < 100; maxWorkers++ {
+		a := asyncContext{maxWorkers: int32(maxWorkers)}
+		for i := int32(0); i < 10; i++ {
+			if a.batchIdxToWorkerIdx(i) != i%a.maxWorkers {
+				t.Fatalf("batchIdxToWorkerIdx returned %d but expected %d", a.batchIdxToWorkerIdx(i), i%a.maxWorkers)
+			}
+		}
+		for i := int32(0); i < a.maxWorkers; i++ {
+			expectedIdx := int32(i)
+			for _, v := range a.workerIdxToBatchIdxs(i) {
+				if v != expectedIdx {
+					t.Fatalf("workerIdxToBatchIdxs returned %d but expected %d", v, expectedIdx)
+				}
+				expectedIdx += a.maxWorkers
+			}
+		}
+	}
+}
+
+func testWithMockPlugins(n int, f func([]cgo.Handle)) {
+	plugins := make([]sampleAsyncExtract, n)
+	handles := make([]cgo.Handle, n)
+	for i := 0; i < n; i++ {
+		handles[i] = cgo.NewHandle(&plugins[i])
+		plugins[i].SetExtractRequests(sdk.NewExtractRequestPool())
+	}
+	f(handles)
+	for i := 0; i < n; i++ {
+		handles[i].Delete()
+		plugins[i].ExtractRequests().Free()
+	}
+}
+
+// this simulates a C consumer as in extract.c
+func testSimulateAsyncRequest(t testing.TB, a *asyncContext, h cgo.Handle, r *_Ctype_ss_plugin_extract_field) {
+	i := a.handleToBatchIdx(h)
+	a.batch[i].s = unsafe.Pointer(h)
+	a.batch[i].evt = nil
+	a.batch[i].num_fields = 1
+	a.batch[i].fields = r
+
+	atomic.StoreInt32((*int32)(&a.batch[i].lock), state_data_req)
+	for atomic.LoadInt32((*int32)(&a.batch[i].lock)) != state_wait {
+		// spin
+	}
+	if int32(a.batch[i].rc) != sdk.SSPluginSuccess {
+		t.Fatalf("extraction failed with rc %v", int32(a.batch[i].rc))
+	}
+}
+
+func TestAsyncExtract(t *testing.T) {
+	a := asyncContext{}
+	workload := func(nPlugins, nExtractions int) {
+		testWithMockPlugins(nPlugins, func(handles []cgo.Handle) {
+			var wg sync.WaitGroup
+			for _, h := range handles {
+				wg.Add(1)
+				go func(h cgo.Handle) {
+					counter := uint64(0)
+					field, freeField := allocSSPluginExtractField(1, sdk.FieldTypeUint64, "", "")
+					defer freeField()
+
+					// note: StartAsync/StopAsync are not invoked concurrently
+					// in the plugin framework, however we want to test them to
+					// be thread-safe as they are designed
+					a.StartAsync(h, testAllocAsyncBatch)
+					for e := 0; e < nExtractions; e++ {
+						testSimulateAsyncRequest(t, &a, h, field)
+						value := **((**uint64)(unsafe.Pointer(&field.res[0])))
+						if value != counter {
+							panic(fmt.Sprintf("extracted %d but expected %d", value, counter))
+						}
+						counter++
+					}
+					a.StopAsync(h, testReleaseAsyncBatch)
+					wg.Done()
+				}(h)
+			}
+			wg.Wait()
+		})
+	}
+
+	// run with increasing number of concurrent consumers
+	for i := 1; i <= cgo.MaxHandle; i *= 2 {
+		// run with increasing number of extractions
+		for j := 1; j < 10000; j *= 10 {
+			workload(i, j)
+		}
+	}
+}
+
+func TestStartStopAsync(t *testing.T) {
+	nPlugins := cgo.MaxHandle
+	testWithMockPlugins(nPlugins, func(handles []cgo.Handle) {
+		// test unbalanced start/stop calls
+		assertPanic(t, func() {
+			a := asyncContext{}
+			a.StopAsync(handles[0], testReleaseAsyncBatch)
+		})
+		assertPanic(t, func() {
+			a := asyncContext{}
+			a.StartAsync(handles[0], testAllocAsyncBatch)
+			a.StopAsync(handles[0], testReleaseAsyncBatch)
+			a.StopAsync(handles[0], testReleaseAsyncBatch)
+		})
+
+		// test with bad start/stop-handle pair
+		assertPanic(t, func() {
+			a := asyncContext{}
+			a.StartAsync(handles[0], testAllocAsyncBatch)
+			a.StartAsync(handles[1], testAllocAsyncBatch)
+			a.StopAsync(handles[0], testReleaseAsyncBatch)
+			a.StopAsync(handles[0], testReleaseAsyncBatch)
+		})
+
+		// test with inconsistent enabled values
+		a := asyncContext{}
+		enabled := true
+		for i := 0; i < nPlugins; i++ {
+			a.SetAsync(enabled)
+			a.StartAsync(handles[i], testAllocAsyncBatch)
+			enabled = !enabled
+		}
+		for i := 0; i < nPlugins; i++ {
+			a.StopAsync(handles[i], testReleaseAsyncBatch)
+		}
+
+		// test workload after already having started/stopped the same context
+		var wg sync.WaitGroup
+		for _, h := range handles {
+			wg.Add(1)
+			a.StartAsync(h, testAllocAsyncBatch)
+			go func(h cgo.Handle) {
+				counter := uint64(0)
+				field, freeField := allocSSPluginExtractField(1, sdk.FieldTypeUint64, "", "")
+				defer freeField()
+				for e := 0; e < 1000; e++ {
+					testSimulateAsyncRequest(t, &a, h, field)
+					value := **((**uint64)(unsafe.Pointer(&field.res[0])))
+					if value != counter {
+						panic(fmt.Sprintf("extracted %d but expected %d", value, counter))
+					}
+					counter++
+				}
+				wg.Done()
+			}(h)
+		}
+		wg.Wait()
+		for _, h := range handles {
+			a.StopAsync(h, testReleaseAsyncBatch)
+		}
+	})
 }

--- a/pkg/sdk/symbols/extract/async_test.go
+++ b/pkg/sdk/symbols/extract/async_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright (C) 2022 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extract
+
+import "testing"
+
+func TestGetMaxWorkers(t *testing.T) {
+	expected := []int32{0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5}
+	for i, ex := range expected {
+		v := getMaxWorkers(i + 1)
+		if v != ex {
+			t.Fatalf("getMaxWorkers returned %d but expected %d", v, ex)
+		}
+	}
+}

--- a/pkg/sdk/symbols/extract/extract.c
+++ b/pkg/sdk/symbols/extract/extract.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2021 The Falco Authors.
+Copyright (C) 2022 The Falco Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/sdk/symbols/extract/extract.c
+++ b/pkg/sdk/symbols/extract/extract.c
@@ -35,18 +35,18 @@ enum worker_state
 	EXIT_ACK = 3,
 };
 
-static async_extractor_info *s_async_extractor_ctx = NULL;
+static async_extractor_info *s_async_ctx_batch = NULL;
 
 async_extractor_info *async_init(size_t size)
 {
-	s_async_extractor_ctx = (async_extractor_info *)malloc(sizeof(async_extractor_info) * size);
-	return s_async_extractor_ctx;
+	s_async_ctx_batch = (async_extractor_info *)malloc(sizeof(async_extractor_info) * size);
+	return s_async_ctx_batch;
 }
 
 void async_deinit()
 {
-	free(s_async_extractor_ctx);
-	s_async_extractor_ctx = NULL;
+	free(s_async_ctx_batch);
+	s_async_ctx_batch = NULL;
 }
 
 // Defined in extract.go
@@ -60,25 +60,32 @@ static inline int32_t async_extract_request(ss_plugin_t *s,
 											uint32_t num_fields,
 											ss_plugin_extract_field *fields)
 {
-	// Since no concurrent requests are supported,
-	// we assume worker is already in WAIT state
+	// note: concurrent requests are supported on the context batch, but each
+	// slot with a different value of ss_plugin_t *s. As such, for each lock
+	// we assume worker is already in WAIT state. This is possible because
+	// ss_plugin_t *s is an integer number representing a cgo.Handle, and can
+	// have values in the range of [1, cgo.MaxHandle]
+	//
+	// todo(jasondellaluce): this is dependent on the implementation of our
+	// cgo.Handle to optimize performance, so change this if we ever change
+	// how cgo.Handles are represented
 
 	// Set input data
-	s_async_extractor_ctx->s = s;
-	s_async_extractor_ctx->evt = evt;
-	s_async_extractor_ctx->num_fields = num_fields;
-	s_async_extractor_ctx->fields = fields;
+	s_async_ctx_batch[(size_t)s - 1].s = s;
+	s_async_ctx_batch[(size_t)s - 1].evt = evt;
+	s_async_ctx_batch[(size_t)s - 1].num_fields = num_fields;
+	s_async_ctx_batch[(size_t)s - 1].fields = fields;
 
 	// notify data request
-	atomic_store_explicit(&s_async_extractor_ctx->lock, DATA_REQ, memory_order_seq_cst);
+	atomic_store_explicit(&s_async_ctx_batch[(size_t)s - 1].lock, DATA_REQ, memory_order_seq_cst);
 
 	// busy-wait until worker completation
-	while (atomic_load_explicit(&s_async_extractor_ctx->lock, memory_order_seq_cst) != WAIT);
+	while (atomic_load_explicit(&s_async_ctx_batch[(size_t)s - 1].lock, memory_order_seq_cst) != WAIT);
 
-	return s_async_extractor_ctx->rc;
+	return s_async_ctx_batch[(size_t)s - 1].rc;
 }
 
-// This is the plugin API function. If s_async_extractor_ctx is
+// This is the plugin API function. If s_async_ctx_batch is
 // non-NULL, it calls the async extractor function. Otherwise, it
 // calls the synchronous extractor function.
 FALCO_PLUGIN_SDK_PUBLIC int32_t plugin_extract_fields(ss_plugin_t *s,
@@ -86,7 +93,7 @@ FALCO_PLUGIN_SDK_PUBLIC int32_t plugin_extract_fields(ss_plugin_t *s,
 							  uint32_t num_fields,
 							  ss_plugin_extract_field *fields)
 {
-	if (s_async_extractor_ctx != NULL)
+	if (s_async_ctx_batch != NULL)
 	{
 		return async_extract_request(s, evt, num_fields, fields);
 	}

--- a/pkg/sdk/symbols/extract/extract.c
+++ b/pkg/sdk/symbols/extract/extract.c
@@ -37,9 +37,9 @@ enum worker_state
 
 static async_extractor_info *s_async_extractor_ctx = NULL;
 
-async_extractor_info *async_init()
+async_extractor_info *async_init(size_t size)
 {
-	s_async_extractor_ctx = (async_extractor_info *)malloc(sizeof(async_extractor_info));
+	s_async_extractor_ctx = (async_extractor_info *)malloc(sizeof(async_extractor_info) * size);
 	return s_async_extractor_ctx;
 }
 

--- a/pkg/sdk/symbols/extract/extract.h
+++ b/pkg/sdk/symbols/extract/extract.h
@@ -34,5 +34,5 @@ typedef struct async_extractor_info
 	int32_t rc;
 } async_extractor_info;
 
-async_extractor_info *async_init();
+async_extractor_info *async_init(size_t size);
 void async_deinit();


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

Following up the discussion of #62, this PR implements the **P3-S4** approach to support concurrent extraction request with the async extraction optimization. The design is as follows.

![Blank board](https://user-images.githubusercontent.com/13836700/180463457-0ca02bbf-ef38-430c-8d3e-e58d5f3c2a70.png)

We have **N** concurrent consumers from the C world, **N** locks shared between C and Go, and **M** async workers in the Go world. The shared spinlocks are the point of synchronization between the C consumers and the Go workers. There is a 1-1 mapping between a C consumer and a shared lock, so there are no collisions between consumers on the same lock. As such, each consumer will be served always by the same one worker. On the contrary, each worker synchronizes with 1+ locks (and consumers), with a given rotation policy (round-robin for now). The number of workers M, is not necessarily correlated con the number of consumers N. Note, each worker heavily occupies the CPU for small time bursts so M should be less than `runtime.GOMAXPROCS`.

**Which issue(s) this PR fixes**:

Fixes #62

**Special notes for your reviewer**:

As for the proposed design, there few implementation choices:
- The async optimization is disabled if `runtime.GOMAXPROCS < 2`
- The number of async workers active at a given time is between 0 and M. The value M representing the maximum spawnable workers is computed as`log2(runtime.GOMAXPROCS)` at the first call to `extract.StartAsync`. The rationale is:
  - In systems with limited resources, the number of workers will be 1 or very limited to prevent CPU abuse
  - On systems with many cores available, the optimization will use more workers but it will follow a logarithmic curve which is bettern than any linear one
  - By controlling runtime.GOMAXPROCS (either at runtime or through env var), users can control the max number of workers
- Workers are spawned only when number of consumers require them. As such, in reality the number of async workers active at a given time is `min(N, M)`. When all the locks synched with a worker become unused, the worker is stopped.
- Async worker lock collision is avoided by partitioning the slots by modulo. Each worker has an integer index and will just loop over slots at positions at `(workerIndex + maxWorkers * i)`. This ensures that multiple async workers never collide trying to sync on the same slot. For example, assuming a maximum number of 3 workers:
  - Worker 0 will sync over batch slots: 0, 3, 6, 9, ...
  - Worker 1 will sync over batch slots: 1, 4, 7, 10, ...
  - Worker 2 will sync over batch slots: 2, 5, 8, 11, ...
- It is allowed for concurrent consumers to decide whether using the async optimization or not. Different plugins can safely set different `extract.SetAsync` values.

**Does this PR introduce a user-facing change?**:

```release-note
refactor(pkg/sdk/symbols/extract): support concurrent consumers in async extraction optimization
```
