### PR TITLE
update(pkg/cgo): set MaxHandle to 255

### DIFF
--- a/pkg/cgo/handle.go
+++ b/pkg/cgo/handle.go
@@ -43,7 +43,7 @@ package cgo
 type Handle uintptr
 
 // MaxHandle is the largest value that an Handle can hold
-const MaxHandle = 32 - 1
+const MaxHandle = 256 - 1
 
 var (
 	handles  [MaxHandle + 1]interface{} // [int]interface{}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

This follows up the changes of https://github.com/falcosecurity/falco/pull/2430. After that PR is merged, the number of plugins initialized at a given time (holding a valid Handle) will grow during a dry run. As such, the max number of assignable handles has been grown to a reasonably bigger number.

Note that even though MaxHandle influences the implementation of our async extraction optimization, there should be no performance regression due to the sync batch slots being skipped if unused (see: https://github.com/falcosecurity/plugin-sdk-go/blob/3856dc775cc8ab7f0043f51d5bd7191b72454339/pkg/sdk/symbols/extract/async.go#L187). I checked for the absence of performance regressions by using the `benchmarks/async` benchmark tool.

In the past, the value 32 was just set to have an "as low as possible" value to be changed at future needs, so this should be safe from both a functional and performance perspective.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
update(pkg/cgo): set MaxHandle to 255
```
