### PR TITLE
fix compilation errors with latest glibc and Go versions

### DIFF
--- a/benchmarks/async/Makefile
+++ b/benchmarks/async/Makefile
@@ -25,5 +25,5 @@ clean:
 
 $(OUTPUT): bench.cpp bench.go
 	mkdir -p $(OUTPUTDIR)
-	GODEBUG=cgocheck=2 $(GO) build -buildmode=c-archive -o $(OUTPUTGO) bench.go
+	GODEBUG=cgocheck=1 $(GO) build -buildmode=c-archive -o $(OUTPUTGO) bench.go
 	$(CXX) bench.cpp $(OUTPUTGO) -std=c++11 -pthread -o $(OUTPUT)

--- a/examples/custom/Makefile
+++ b/examples/custom/Makefile
@@ -23,4 +23,4 @@ clean:
 	@rm -f *.so *.h
 
 $(OUTPUT): *.go
-	@GODEBUG=cgocheck=2 $(GO) build -buildmode=c-shared -o $(OUTPUT)
+	@GODEBUG=cgocheck=1 $(GO) build -buildmode=c-shared -o $(OUTPUT)

--- a/examples/extractor/Makefile
+++ b/examples/extractor/Makefile
@@ -23,4 +23,4 @@ clean:
 	@rm -f *.so *.h
 
 $(OUTPUT): *.go
-	@GODEBUG=cgocheck=2 $(GO) build -buildmode=c-shared -o $(OUTPUT)
+	@GODEBUG=cgocheck=1 $(GO) build -buildmode=c-shared -o $(OUTPUT)

--- a/examples/full/Makefile
+++ b/examples/full/Makefile
@@ -23,4 +23,4 @@ clean:
 	@rm -f *.so *.h
 
 $(OUTPUT): *.go
-	@GODEBUG=cgocheck=2 $(GO) build -buildmode=c-shared -o $(OUTPUT)
+	@GODEBUG=cgocheck=1 $(GO) build -buildmode=c-shared -o $(OUTPUT)

--- a/examples/source/Makefile
+++ b/examples/source/Makefile
@@ -23,5 +23,5 @@ clean:
 	@rm -f *.so *.h
 
 $(OUTPUT): *.go
-	@GODEBUG=cgocheck=2 $(GO) build -buildmode=c-shared -o $(OUTPUT)
+	@GODEBUG=cgocheck=1 $(GO) build -buildmode=c-shared -o $(OUTPUT)
 

--- a/pkg/sdk/strlcpy.h
+++ b/pkg/sdk/strlcpy.h
@@ -27,7 +27,7 @@ limitations under the License.
   \return The length of the source string.
 */
 
-static inline size_t strlcpy(char *dst, const char *src, size_t size) {
+inline size_t strlcpy(char *dst, const char *src, size_t size) {
     size_t srcsize = strlen(src);
     if (size == 0) {
         return srcsize;


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
fix: solve compilation errors with glibc 2.38 and Go 1.21
```
