### PR TITLE
fix(pkg/cgo): solve data races when assigning/deleting and accessing handles

### DIFF
--- a/pkg/cgo/handle_test.go
+++ b/pkg/cgo/handle_test.go
@@ -19,6 +19,7 @@ package cgo
 
 import (
 	"reflect"
+	"sync/atomic"
 	"testing"
 )
 
@@ -61,7 +62,7 @@ func TestHandle(t *testing.T) {
 
 	siz := 0
 	for i := 0; i < MaxHandle; i++ {
-		if handles[i] != &noHandle {
+		if atomic.LoadPointer(&handles[i]) != noHandle {
 			siz++
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind cleanup

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

Due to how shared object loading works in Linux and in the falcosecurity libs, I discovered that concurrent (and legitimate, as per generalized non-Falco libs consumers) operations to plugins written in Go led to panics and segfaults caused by data races in case of many workers.

So far my research led to discovering that this kind of issues disappear when re-working the `cgo.Handle` primitives to support proper synchronization.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
fix(pkg/cgo): solve data races when assigning/deleting and accessing handles
```
